### PR TITLE
ci: publish to GitHub Packages on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write   # create GitHub release
   id-token: write   # npm provenance attestation
+  packages: write   # publish to GitHub Packages
 
 jobs:
   release:
@@ -95,3 +96,17 @@ jobs:
         run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to GitHub Packages
+        run: |
+          # GitHub Packages requires a scoped name — publish as @iamvirul/council-mcp
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.name = '@iamvirul/council-mcp';
+            pkg.publishConfig = { registry: 'https://npm.pkg.github.com' };
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Published to GitHub Packages as `@iamvirul/council-mcp` in addition to npm — package now appears in the GitHub repository sidebar
+
 ### Security
 - Zod runtime schema validation on all agent JSON responses — prevents malformed or injected agent output from propagating to downstream agents
 - Hard cap of 10 delegated tasks per Executor response — prevents prompt-injection-driven Aide invocation amplification

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The Council
 
 [![npm version](https://img.shields.io/npm/v/council-mcp)](https://www.npmjs.com/package/council-mcp)
+[![GitHub Packages](https://img.shields.io/badge/GitHub%20Packages-%40iamvirul%2Fcouncil--mcp-blue?logo=github)](https://github.com/iamvirul/the-council/pkgs/npm/council-mcp)
 [![CI](https://github.com/iamvirul/the-council/actions/workflows/ci.yml/badge.svg)](https://github.com/iamvirul/the-council/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -146,6 +147,15 @@ Add this to your Claude Code MCP config:
 Restart Claude Code and the tools will appear.
 
 **No API key needed.** The Council runs inside your existing Claude Code session and inherits its authentication.
+
+### Registries
+
+The package is published to two registries on every release:
+
+| Registry | Package |
+|---|---|
+| [npm](https://www.npmjs.com/package/council-mcp) | `council-mcp` |
+| [GitHub Packages](https://github.com/iamvirul/the-council/pkgs/npm/council-mcp) | `@iamvirul/council-mcp` |
 
 ---
 


### PR DESCRIPTION
## Summary

- Release workflow now publishes to GitHub Packages as `@iamvirul/council-mcp` after the npm publish step
- Uses `GITHUB_TOKEN` (no extra secret needed) with `packages: write` permission
- Package will appear in the GitHub repository sidebar under "Packages"

## Docs

- Added GitHub Packages badge to README header
- Added registries table to the Installation section showing both npm and GitHub Packages
- CHANGELOG Unreleased section updated

## Test plan

- [ ] Merge and tag `v0.1.1` (or any new version) — release workflow should publish to both npmjs.com and GitHub Packages
- [ ] Package appears at github.com/iamvirul/the-council under "Packages" after release
