### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-04-12
+
 ### Added
 - Published to GitHub Packages as `@iamvirul/council-mcp` in addition to npm — package now appears in the GitHub repository sidebar
 
@@ -40,5 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Executor runs with explicit `permissionMode: 'acceptEdits'` rather than relying on inherited default
 - `@anthropic-ai/claude-agent-sdk` pinned to `^0.2.101` (no `latest` in production)
 
-[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/iamvirul/the-council/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/iamvirul/the-council/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "council-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Three-tier AI agent MCP orchestration system: Chancellor (Opus), Executor (Sonnet), Aide (Haiku)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Version bump to `0.1.1`. No code changes — this release ships the GitHub Packages publishing added in #2.

## Changes

- `package.json` version bumped to `0.1.1`
- `CHANGELOG.md` Unreleased entries moved under `[0.1.1] - 2026-04-12`

## Release

After merging, tag main to trigger the release workflow:

```
git tag v0.1.1 && git push origin v0.1.1
```

This will publish `council-mcp@0.1.1` to npm and `@iamvirul/council-mcp@0.1.1` to GitHub Packages.
