### PR TITLE
fix: reconfigure npm registry before GitHub Packages publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,12 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Setup Node for GitHub Packages
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          registry-url: https://npm.pkg.github.com
+
       - name: Publish to GitHub Packages
         run: |
           # GitHub Packages requires a scoped name — publish as @iamvirul/council-mcp


### PR DESCRIPTION
## Problem

The GitHub Packages publish step was failing with `ENEEDAUTH` because `setup-node` had configured `.npmrc` for `registry.npmjs.org` only. When the publish step switched to `npm.pkg.github.com`, the `NODE_AUTH_TOKEN` wasn't wired up for that registry.

## Fix

Added a second `setup-node` step immediately before the GitHub Packages publish, pointing at `https://npm.pkg.github.com`. This rewrites `.npmrc` so `NODE_AUTH_TOKEN` is correctly scoped to the GitHub Packages registry for that step.

## Test plan

- [ ] Merge, then trigger a release tag — GitHub Packages publish step should succeed and `@iamvirul/council-mcp` appears under the repo's Packages sidebar
