### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-04-12
+
+### Fixed
+- Release workflow now reconfigures npm registry to `npm.pkg.github.com` before publishing to GitHub Packages, fixing `ENEEDAUTH` on the GitHub Packages publish step
+
 ## [0.1.1] - 2026-04-12
 
 ### Added
@@ -42,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Executor runs with explicit `permissionMode: 'acceptEdits'` rather than relying on inherited default
 - `@anthropic-ai/claude-agent-sdk` pinned to `^0.2.101` (no `latest` in production)
 
-[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/iamvirul/the-council/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/iamvirul/the-council/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/iamvirul/the-council/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "council-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Three-tier AI agent MCP orchestration system: Chancellor (Opus), Executor (Sonnet), Aide (Haiku)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bump to `0.1.2` because `0.1.1` was already published to npm during a failed release attempt (npm publish succeeded, GitHub Packages publish failed). npm does not allow overwriting published versions.

## Changes

- `package.json` version bumped to `0.1.2`
- `CHANGELOG.md` updated with `[0.1.2]` entry

## Release

After merging, tag to trigger the release workflow:

```
git tag v0.1.2 && git push origin v0.1.2
```
