### PR TITLE
chore: add PR template and issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Every file in the repo — @iamvirul is required reviewer on all PRs
+* @iamvirul

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug report
+about: Something is broken or behaving unexpectedly
+title: "bug: "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+<!-- What went wrong? Be specific. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behaviour
+
+<!-- What should have happened? -->
+
+## Actual behaviour
+
+<!-- What actually happened? Include error messages and stack traces if available. -->
+
+## Environment
+
+- council-mcp version:
+- Node.js version (`node -v`):
+- OS:
+- Claude Code version (if relevant):
+
+## Logs
+
+<!--
+Run with structured logs visible:
+  npx council-mcp 2>&1 | head -100
+
+Paste relevant log output here. Remove any sensitive data first.
+-->
+
+```
+paste logs here
+```
+
+## Additional context
+
+<!-- Anything else that might be relevant. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/iamvirul/the-council/security/advisories/new
+    about: Report a security vulnerability privately via GitHub Security Advisories. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: "feat: "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+<!-- What problem are you trying to solve? Why does the current behaviour fall short? -->
+
+## Proposed solution
+
+<!-- Describe what you want. Be as specific as you can. -->
+
+## Alternatives considered
+
+<!-- What other approaches did you think about? Why are they worse than your proposal? -->
+
+## Additional context
+
+<!-- Screenshots, related issues, links to prior art, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## What does this PR do?
+
+<!-- One or two sentences. What problem does it solve, or what does it add? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] CI / tooling
+- [ ] Documentation
+- [ ] Release / version bump
+
+## Related issue
+
+<!-- Closes #123 -->
+
+## Changes
+
+<!--
+Bullet points. Focus on the "why", not just the "what".
+The diff already shows what changed.
+-->
+
+## Test plan
+
+- [ ] <!-- Describe how you verified this works -->
+
+## Checklist
+
+- [ ] `npm run type-check` passes
+- [ ] `npm run build` passes
+- [ ] No new `any` types or unvalidated external data
+- [ ] No secrets, credentials, or hardcoded values introduced
+- [ ] CHANGELOG.md updated (for user-facing changes)


### PR DESCRIPTION
## What does this PR do?

Adds GitHub PR and issue templates to standardise contributions and keep issues actionable.

## Type of change

- [x] CI / tooling

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md` - checklist covering type of change, related issue, test plan, and type-check/build/security requirements
- `.github/ISSUE_TEMPLATE/bug_report.md` - structured bug report with reproduction steps, environment info, and log section
- `.github/ISSUE_TEMPLATE/feature_request.md` - feature request with problem/solution/alternatives structure
- `.github/ISSUE_TEMPLATE/config.yml` - disables blank issues and redirects security reports to GitHub Security Advisories
