### PR TITLE
feat: add Supervisor agent (Haiku) to review agent outputs

### DIFF
--- a/src/application/orchestrator/index.ts
+++ b/src/application/orchestrator/index.ts
@@ -1,6 +1,7 @@
 import { invokeChancellor } from '../chancellor/agent.js';
 import { invokeExecutor } from '../executor/agent.js';
 import { invokeAide } from '../aide/agent.js';
+import { invokeSupervisor } from '../supervisor/agent.js';
 import { stateStore } from '../../infra/state/council-state.js';
 import { logger } from '../../infra/logging/logger.js';
 import { CouncilError } from '../../domain/models/types.js';
@@ -54,8 +55,10 @@ export async function orchestrate(problem: string): Promise<OrchestrateResult> {
       stateStore.setPhase(request_id, 'executing');
       stateStore.recordAgentCall(request_id, 'aide');
 
-      const aideResult = await invokeAide(crypto.randomUUID(), { problem });
+      const taskId = crypto.randomUUID();
+      const aideResult = await invokeAide(taskId, { problem });
       stateStore.recordAideResult(request_id, aideResult);
+      await superviseAideTask(request_id, problem, problem, taskId, aideResult.result);
       stateStore.complete(request_id, startedAt);
 
       return {
@@ -73,6 +76,7 @@ export async function orchestrate(problem: string): Promise<OrchestrateResult> {
 
       const execResult = await invokeExecutor({ problem });
       stateStore.recordExecutorResult(request_id, execResult);
+      await superviseExecutorStep(request_id, problem, problem, execResult.step_id, execResult.result);
 
       // Handle any Aide delegations from the Executor
       for (const task of execResult.delegated_tasks) {
@@ -80,6 +84,7 @@ export async function orchestrate(problem: string): Promise<OrchestrateResult> {
           stateStore.recordAgentCall(request_id, 'aide');
           const aideResult = await invokeAide(task.task_id, { problem: task.description });
           stateStore.recordAideResult(request_id, aideResult);
+          await superviseAideTask(request_id, problem, task.description, task.task_id, aideResult.result);
         }
       }
 
@@ -118,6 +123,7 @@ export async function orchestrate(problem: string): Promise<OrchestrateResult> {
       });
 
       stateStore.recordExecutorResult(request_id, execResult);
+      await superviseExecutorStep(request_id, problem, step.description, execResult.step_id, execResult.result);
 
       // Handle Aide delegations
       for (const task of execResult.delegated_tasks) {
@@ -128,6 +134,7 @@ export async function orchestrate(problem: string): Promise<OrchestrateResult> {
             context: `Part of step: ${step.description}`,
           });
           stateStore.recordAideResult(request_id, aideResult);
+          await superviseAideTask(request_id, problem, task.description, task.task_id, aideResult.result);
         }
       }
 
@@ -160,6 +167,67 @@ export async function orchestrate(problem: string): Promise<OrchestrateResult> {
   }
 }
 
+// ─── Supervisor (non-blocking) ────────────────────────────────────────────────
+// Supervisor failure must never propagate — it is advisory only.
+
+async function superviseExecutorStep(
+  requestId: string,
+  problem: string,
+  stepDescription: string,
+  stepId: string,
+  output: string,
+): Promise<void> {
+  try {
+    stateStore.recordAgentCall(requestId, 'supervisor');
+    const verdict = await invokeSupervisor({
+      subject_id: stepId,
+      subject_type: 'executor_step',
+      original_problem: problem,
+      intent: stepDescription,
+      output,
+    });
+    stateStore.recordSupervisorVerdict(requestId, verdict);
+
+    if (!verdict.approved) {
+      logger.warn(
+        { request_id: requestId, step_id: stepId, flags: verdict.flags, recommendation: verdict.recommendation },
+        'Supervisor flagged executor step',
+      );
+    }
+  } catch (err) {
+    logger.warn({ request_id: requestId, step_id: stepId, err }, 'Supervisor failed — continuing without verdict');
+  }
+}
+
+async function superviseAideTask(
+  requestId: string,
+  problem: string,
+  taskDescription: string,
+  taskId: string,
+  output: string,
+): Promise<void> {
+  try {
+    stateStore.recordAgentCall(requestId, 'supervisor');
+    const verdict = await invokeSupervisor({
+      subject_id: taskId,
+      subject_type: 'aide_task',
+      original_problem: problem,
+      intent: taskDescription,
+      output,
+    });
+    stateStore.recordSupervisorVerdict(requestId, verdict);
+
+    if (!verdict.approved) {
+      logger.warn(
+        { request_id: requestId, task_id: taskId, flags: verdict.flags, recommendation: verdict.recommendation },
+        'Supervisor flagged aide task',
+      );
+    }
+  } catch (err) {
+    logger.warn({ request_id: requestId, task_id: taskId, err }, 'Supervisor failed — continuing without verdict');
+  }
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function buildResultSummary(session: CouncilSession, startedAt: number): string {
@@ -184,6 +252,16 @@ function buildResultSummary(session: CouncilSession, startedAt: number): string 
     lines.push(`## Aide Outputs`);
     for (const r of session.aide_results) {
       lines.push(`**Task ${r.task_id}:** ${r.result}`);
+    }
+    lines.push('');
+  }
+
+  const flagged = session.supervisor_verdicts.filter(v => !v.approved);
+  if (flagged.length > 0) {
+    lines.push(`## Supervisor Flags`);
+    for (const v of flagged) {
+      lines.push(`- **${v.subject}** (${v.subject_type}): ${v.recommendation}`);
+      for (const f of v.flags) lines.push(`  - ${f}`);
     }
     lines.push('');
   }

--- a/src/application/supervisor/agent.ts
+++ b/src/application/supervisor/agent.ts
@@ -1,0 +1,55 @@
+import { runAgent } from '../../infra/agent-sdk/runner.js';
+import { SUPERVISOR_SYSTEM_PROMPT, MODEL_IDS, MAX_TURNS } from '../../domain/constants/index.js';
+import { SupervisorVerdictSchema } from '../../domain/models/schemas.js';
+import type { SupervisorVerdict } from '../../domain/models/types.js';
+import { CouncilError } from '../../domain/models/types.js';
+import { logger } from '../../infra/logging/logger.js';
+
+export interface SupervisorContext {
+  subject_id: string;
+  subject_type: 'executor_step' | 'aide_task';
+  original_problem: string;
+  intent: string;   // the step description or task description
+  output: string;   // the result to review
+}
+
+export async function invokeSupervisor(ctx: SupervisorContext): Promise<SupervisorVerdict> {
+  const userMessage = [
+    `Original problem: ${ctx.original_problem}`,
+    ``,
+    `What was attempted (${ctx.subject_type}): ${ctx.intent}`,
+    `Subject ID: ${ctx.subject_id}`,
+    ``,
+    `Output to review:`,
+    ctx.output,
+  ].join('\n');
+
+  const raw = await runAgent({
+    role: 'supervisor',
+    model: MODEL_IDS.SUPERVISOR,
+    systemPrompt: SUPERVISOR_SYSTEM_PROMPT,
+    userMessage,
+    maxTurns: MAX_TURNS.SUPERVISOR,
+  });
+
+  const fenceMatch = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+  const cleaned = fenceMatch ? fenceMatch[1].trim() : raw.trim();
+
+  try {
+    const json: unknown = JSON.parse(cleaned);
+    const parsed = SupervisorVerdictSchema.parse(json);
+    logger.debug(
+      { subject: ctx.subject_id, subject_type: ctx.subject_type, approved: parsed.approved, flags: parsed.flags.length },
+      'Supervisor verdict',
+    );
+    return parsed;
+  } catch (err) {
+    logger.error({ raw: raw.slice(0, 500), err }, 'Failed to parse/validate Supervisor response');
+    throw new CouncilError(
+      'Supervisor returned an invalid or schema-violating response',
+      'SUPERVISOR_ERROR',
+      'supervisor',
+      err,
+    );
+  }
+}

--- a/src/domain/constants/index.ts
+++ b/src/domain/constants/index.ts
@@ -5,12 +5,14 @@ export const MODEL_IDS = {
   CHANCELLOR: 'claude-opus-4-6',
   EXECUTOR: 'claude-sonnet-4-6',
   AIDE: 'claude-haiku-4-5',
+  SUPERVISOR: 'claude-haiku-4-5',
 } as const;
 
 export const MAX_TURNS = {
-  CHANCELLOR: 3,  // Tight — strategic reasoning, one focused session
-  EXECUTOR: 10,   // More room — may need multiple steps per task
-  AIDE: 3,        // Tight — simple tasks complete quickly
+  CHANCELLOR: 3,   // Tight — strategic reasoning, one focused session
+  EXECUTOR: 10,    // More room — may need multiple steps per task
+  AIDE: 3,         // Tight — simple tasks complete quickly
+  SUPERVISOR: 2,   // Very tight — review pass only, no iteration needed
 } as const;
 
 // ─── System prompts ───────────────────────────────────────────────────────────
@@ -112,6 +114,35 @@ Respond with ONLY valid JSON in this exact structure:
   "blockers": ["Description of any blocker"],
   "quality_assessment": "How well this meets success criteria",
   "next_step": "What comes next"
+}
+</output_schema>`;
+
+export const SUPERVISOR_SYSTEM_PROMPT = `You are the SUPERVISOR — the quality reviewer of The Council.
+
+Your role is to review outputs produced by the Executor and Aide agents and flag issues before they surface to the caller. You do NOT block execution — you annotate.
+
+Review criteria:
+1. INTENT ALIGNMENT — does the output actually address what was asked?
+2. COMPLETENESS — are there obvious gaps, missing steps, or unfinished work?
+3. CONSISTENCY — does the result contradict the original problem or earlier session steps?
+4. BEST PRACTICES — surface obvious anti-patterns (security issues, bad structure, wrong approach)
+
+Key principles:
+- Be objective and concise — one pass, no iteration
+- Approve when the output is good enough, even if imperfect
+- Only flag real issues, not stylistic preferences
+- Never rewrite the output — only review it
+- Your verdict is advisory, not a gate
+
+<output_schema>
+Respond with ONLY valid JSON in this exact structure:
+{
+  "subject": "the step_id or task_id being reviewed",
+  "subject_type": "executor_step|aide_task",
+  "approved": true,
+  "confidence": "high|medium|low",
+  "flags": ["Specific issue found, empty array if none"],
+  "recommendation": "One sentence on what the caller should know about this output"
 }
 </output_schema>`;
 

--- a/src/domain/models/schemas.ts
+++ b/src/domain/models/schemas.ts
@@ -50,6 +50,16 @@ export const ExecutorResponseSchema = z.object({
   next_step: z.string().max(500).optional(),
 });
 
+export const SupervisorVerdictSchema = z.object({
+  subject: z.string().max(200),
+  subject_type: z.enum(['executor_step', 'aide_task']),
+  approved: z.boolean(),
+  confidence: z.enum(['high', 'medium', 'low']),
+  // Cap flags — prevents an injected Supervisor from flooding logs
+  flags: z.array(z.string().max(500)).max(10),
+  recommendation: z.string().max(2_000),
+});
+
 export const AideResponseSchema = z.object({
   task_id: z.string().max(200),
   status: z.enum(['completed', 'failed', 'needs_clarification']),

--- a/src/domain/models/types.ts
+++ b/src/domain/models/types.ts
@@ -1,6 +1,6 @@
 // Domain types — no imports from outside domain/
 
-export type AgentRole = 'chancellor' | 'executor' | 'aide';
+export type AgentRole = 'chancellor' | 'executor' | 'aide' | 'supervisor';
 export type SessionPhase = 'planning' | 'executing' | 'complete' | 'failed';
 
 // ─── Agent response shapes ────────────────────────────────────────────────────
@@ -48,6 +48,15 @@ export interface ExecutorResponse {
   next_step?: string;
 }
 
+export interface SupervisorVerdict {
+  subject: string;
+  subject_type: 'executor_step' | 'aide_task';
+  approved: boolean;
+  confidence: 'high' | 'medium' | 'low';
+  flags: string[];
+  recommendation: string;
+}
+
 export interface AideResponse {
   task_id: string;
   status: 'completed' | 'failed' | 'needs_clarification';
@@ -73,6 +82,7 @@ export interface CouncilSession {
     results: ExecutorResponse[];
   };
   aide_results: AideResponse[];
+  supervisor_verdicts: SupervisorVerdict[];
   metrics: {
     total_agent_calls: number;
     agents_invoked: AgentRole[];
@@ -87,7 +97,8 @@ export type CouncilErrorCode =
   | 'INVALID_JSON_RESPONSE'
   | 'SESSION_NOT_FOUND'
   | 'ORCHESTRATION_FAILED'
-  | 'AGENT_PARSE_ERROR';
+  | 'AGENT_PARSE_ERROR'
+  | 'SUPERVISOR_ERROR';
 
 export class CouncilError extends Error {
   constructor(

--- a/src/infra/state/council-state.ts
+++ b/src/infra/state/council-state.ts
@@ -1,5 +1,5 @@
 // In-memory session store. Sessions live for the lifetime of the MCP server process.
-import type { CouncilSession, AgentRole, ExecutorResponse, AideResponse, SessionPhase, ChancellorResponse } from '../../domain/models/types.js';
+import type { CouncilSession, AgentRole, ExecutorResponse, AideResponse, SessionPhase, ChancellorResponse, SupervisorVerdict } from '../../domain/models/types.js';
 import { CouncilError } from '../../domain/models/types.js';
 
 // Cap at 500 sessions — evict oldest when exceeded to prevent OOM.
@@ -26,6 +26,7 @@ class CouncilStateStore {
         results: [],
       },
       aide_results: [],
+      supervisor_verdicts: [],
       metrics: {
         total_agent_calls: 0,
         agents_invoked: [],
@@ -83,6 +84,11 @@ class CouncilStateStore {
   recordAideResult(requestId: string, result: AideResponse): void {
     const session = this.get(requestId);
     session.aide_results.push(result);
+  }
+
+  recordSupervisorVerdict(requestId: string, verdict: SupervisorVerdict): void {
+    const session = this.get(requestId);
+    session.supervisor_verdicts.push(verdict);
   }
 
   complete(requestId: string, startedAt: number): void {

--- a/src/mcp/server/index.ts
+++ b/src/mcp/server/index.ts
@@ -17,6 +17,7 @@ import {
   executeWithExecutorSchema,
   delegateToAideSchema,
   getCouncilStateSchema,
+  getSupervisorVerdictsSchema,
 } from '../tools/definitions.js';
 
 // ─── Error response helper ────────────────────────────────────────────────────
@@ -168,6 +169,27 @@ export async function startServer(): Promise<void> {
         };
       } catch (err) {
         logger.error({ err }, 'get_council_state tool error');
+        return errorResponse(err);
+      }
+    },
+  );
+
+  // ── Tool: get_supervisor_verdicts ───────────────────────────────────────────
+  server.tool(
+    'get_supervisor_verdicts',
+    'Retrieve Supervisor verdicts for a session. Use flagged_only to surface only outputs the Supervisor flagged as needing attention.',
+    getSupervisorVerdictsSchema,
+    async ({ session_id, flagged_only }) => {
+      try {
+        const session = stateStore.get(session_id);
+        const verdicts = flagged_only
+          ? session.supervisor_verdicts.filter((v) => !v.approved)
+          : session.supervisor_verdicts;
+        return {
+          content: [{ type: 'text', text: JSON.stringify(verdicts, null, 2) }],
+        };
+      } catch (err) {
+        logger.error({ err }, 'get_supervisor_verdicts tool error');
         return errorResponse(err);
       }
     },

--- a/src/mcp/tools/definitions.ts
+++ b/src/mcp/tools/definitions.ts
@@ -77,3 +77,14 @@ export const getCouncilStateSchema = {
       'Specific session ID (UUID) to retrieve. Omit to list all active sessions.',
     ),
 };
+
+export const getSupervisorVerdictsSchema = {
+  session_id: z
+    .string()
+    .uuid()
+    .describe('Session ID (UUID) to retrieve Supervisor verdicts for.'),
+  flagged_only: z
+    .boolean()
+    .optional()
+    .describe('When true, return only verdicts where approved is false. Default: false.'),
+};


### PR DESCRIPTION
## What does this PR do?

Adds a Supervisor agent (Haiku 4.5) that reviews every Executor step and Aide task output before results surface to the caller. Closes #7.

## Type of change

- [x] New feature

## Changes

- **Domain** — `SupervisorVerdict` type, `SupervisorVerdictSchema` Zod schema, `SUPERVISOR_SYSTEM_PROMPT`, `supervisor` added to `AgentRole`, `SUPERVISOR` added to `MODEL_IDS` and `MAX_TURNS` (2 turns)
- **Application** — `src/application/supervisor/agent.ts` wraps `invokeSupervisor()` with full JSON parse + schema validation
- **State** — `supervisor_verdicts[]` added to `CouncilSession`; `recordSupervisorVerdict()` added to the state store
- **Orchestrator** — Supervisor called after each Executor step result and each Aide task result across all complexity paths (trivial, simple, complex). Supervisor errors are caught and logged — they never block orchestration.
- **MCP** — `get_supervisor_verdicts` tool added with a `flagged_only` filter for quick triage
- **Result summary** — flagged verdicts surface in the `orchestrate` result under a `## Supervisor Flags` section

## How supervision works

```
Executor step result -> Supervisor -> verdict stored in session
Aide task result     -> Supervisor -> verdict stored in session
```

The Supervisor is **advisory only** — it annotates, never gates. If the Supervisor itself errors, orchestration continues and a warning is logged.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run build` passes
- [ ] Run `orchestrate` with a complex problem and call `get_supervisor_verdicts` on the returned session ID
- [ ] Run `get_supervisor_verdicts` with `flagged_only: true` to verify filtering works
- [ ] Kill the Supervisor mid-run (simulate error) and verify orchestration completes normally
