### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-12
+
+### Added
+- **Supervisor agent** (Claude Haiku 4.5) — reviews every Executor step result and Aide task output before they surface to the caller. Non-blocking: if the Supervisor errors, orchestration continues and a warning is logged.
+- **`get_supervisor_verdicts` MCP tool** — retrieve all Supervisor verdicts for a session, with optional `flagged_only` filter for quick triage
+- **Supervisor flags in result summary** — flagged outputs appear under a `## Supervisor Flags` section in the `orchestrate` result
+- **`supervisor` added to `AgentRole`** — session metrics now track Supervisor invocations alongside Chancellor, Executor, and Aide
+- **PR template** — standardised pull request checklist for contributions
+- **Issue templates** — bug report and feature request templates; security reports redirect to GitHub Security Advisories
+- **`CODEOWNERS`** — `@iamvirul` set as required reviewer on all files
+
 ## [0.1.2] - 2026-04-12
 
 ### Fixed
@@ -47,7 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Executor runs with explicit `permissionMode: 'acceptEdits'` rather than relying on inherited default
 - `@anthropic-ai/claude-agent-sdk` pinned to `^0.2.101` (no `latest` in production)
 
-[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/iamvirul/the-council/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/iamvirul/the-council/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/iamvirul/the-council/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/iamvirul/the-council/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![CI](https://github.com/iamvirul/the-council/actions/workflows/ci.yml/badge.svg)](https://github.com/iamvirul/the-council/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A three-tier AI agent orchestration system that runs inside Claude Code. No separate API key needed.
+A four-tier AI agent orchestration system that runs inside Claude Code. No separate API key needed.
 
-The Council is a TypeScript [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server with three Claude agents: **Chancellor**, **Executor**, and **Aide**. When you give it a problem, it figures out the complexity and sends it to the right agent. A formatting task goes straight to the fast Aide (Haiku). A coding task goes to the Executor (Sonnet). A design or architecture problem first goes through the Chancellor (Opus) for a plan, then the Executor runs each step, delegating simple sub-tasks to the Aide.
+The Council is a TypeScript [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server with four Claude agents. When you give it a problem, it figures out the complexity and sends it to the right agents. A formatting task goes straight to the fast Aide (Haiku). A coding task goes to the Executor (Sonnet). A design or architecture problem first goes through the Chancellor (Opus) for a plan, then the Executor runs each step, delegating simple sub-tasks to the Aide. After each agent produces output, the Supervisor (Haiku) reviews it for quality and flags any issues before results surface to the caller.
 
 All agents run as sub-agents of your existing Claude Code session, so no extra authentication is needed.
 
@@ -28,21 +28,21 @@ flowchart TD
     CH -->|structured plan| E
     E -->|delegates simple sub-tasks| A
 
-    A -->|AideResponse| ORC
-    E -->|ExecutorResponse| ORC
-    CH -->|ChancellorResponse| ORC
+    A -->|AideResponse| SV[Supervisor\nHaiku 4.5]
+    E -->|ExecutorResponse| SV
+    SV -->|SupervisorVerdict| ORC
 
-    ORC -->|result + session| CC
+    ORC -->|result + verdicts + session| CC
     CC --> U
 ```
 
-Complexity routing uses a fast keyword + word count check. No extra LLM call.
+Complexity routing uses a fast keyword + word count check with no extra LLM call.
 
 | Signal | Complexity | Agents invoked |
 |---|---|---|
-| Word count > 60, or keywords: `plan`, `design`, `architect`, `strategy`, `analyze`, `assess`, `risk` | Complex | Chancellor -> Executor -> Aide (as needed) |
-| Word count 15-60, no strong signal | Simple | Executor -> Aide (as needed) |
-| Word count < 15, keywords: `format`, `convert`, `transform`, `clean`, `list`, `count` | Trivial | Aide only |
+| Word count > 60, or keywords: `plan`, `design`, `architect`, `strategy`, `analyze`, `assess`, `risk` | Complex | Chancellor -> Executor -> Aide -> Supervisor |
+| Word count 15-60, no strong signal | Simple | Executor -> Aide (as needed) -> Supervisor |
+| Word count < 15, keywords: `format`, `convert`, `transform`, `clean`, `list`, `count` | Trivial | Aide -> Supervisor |
 
 ---
 
@@ -53,6 +53,9 @@ Complexity routing uses a fast keyword + word count check. No extra LLM call.
 | **Chancellor** | `claude-opus-4-6` | Deep analysis, planning, risk assessment | None (pure reasoning) | 3 |
 | **Executor** | `claude-sonnet-4-6` | Implementation, code, delegation | `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep` | 10 |
 | **Aide** | `claude-haiku-4-5` | Formatting, data transformation, utilities | None (pure reasoning) | 3 |
+| **Supervisor** | `claude-haiku-4-5` | Output review, quality flags, intent alignment | None (pure reasoning) | 2 |
+
+The Supervisor is **advisory only** — it annotates and flags, never blocks. If the Supervisor errors, orchestration continues and a warning is logged.
 
 ---
 
@@ -66,27 +69,32 @@ sequenceDiagram
     participant CH as Chancellor
     participant EX as Executor
     participant AI as Aide
+    participant SV as Supervisor
 
     User->>CC: "Design a microservices architecture for my e-commerce app"
     CC->>ORC: orchestrate(problem)
     ORC->>ORC: assessComplexity() -> complex
 
     ORC->>CH: invokeChancellor(problem)
-    CH-->>ORC: ChancellorResponse<br/>(analysis, plan[], risks[], delegation_strategy)
+    CH-->>ORC: ChancellorResponse<br/>(analysis, plan[], risks[])
 
     loop For each PlanStep
         ORC->>EX: invokeExecutor(step, plan context)
         EX-->>ORC: ExecutorResponse<br/>(result, delegated_tasks[])
+        ORC->>SV: supervise(executor_step, result)
+        SV-->>ORC: SupervisorVerdict<br/>(approved, flags[])
 
         loop For each delegated_task
-            ORC->>AI: invokeAide(task_id, task description)
+            ORC->>AI: invokeAide(task_id, description)
             AI-->>ORC: AideResponse<br/>(result, quality_check)
+            ORC->>SV: supervise(aide_task, result)
+            SV-->>ORC: SupervisorVerdict<br/>(approved, flags[])
         end
     end
 
     ORC->>ORC: buildResultSummary(session)
-    ORC-->>CC: OrchestrateResult<br/>(result, request_id, session)
-    CC-->>User: Formatted result
+    ORC-->>CC: OrchestrateResult<br/>(result, verdicts, session)
+    CC-->>User: Formatted result + Supervisor flags
 ```
 
 ---
@@ -100,6 +108,7 @@ sequenceDiagram
 | `execute_with_executor` | Invoke the Executor directly for implementation. Has file and shell tool access. | `task`, `plan_context?`, `session_id?` |
 | `delegate_to_aide` | Invoke the Aide directly for simple, well-defined tasks. | `task` (max 2 000 chars), `task_id?`, `context?`, `session_id?` |
 | `get_council_state` | Retrieve session state by ID, or list all active sessions. | `session_id?` |
+| `get_supervisor_verdicts` | Retrieve Supervisor verdicts for a session. Use `flagged_only` to surface only issues. | `session_id`, `flagged_only?` |
 
 ---
 
@@ -165,13 +174,23 @@ The package is published to two registries on every release:
 
 > "Use The Council to format this JSON into a clean, human-readable structure."
 
-Routes to the **Aide** (Haiku 4.5). Fast and cheap.
+Routes to the **Aide** (Haiku 4.5), then the **Supervisor** reviews the output. Fast and cheap.
 
 ### Complex - architecture design
 
 > "Use The Council to design a microservices architecture for my e-commerce app."
 
-Routes to the **Chancellor** (Opus 4.6) for analysis and planning. Each plan step runs through the **Executor** (Sonnet 4.6), which delegates simple sub-tasks to the **Aide**.
+Routes to the **Chancellor** (Opus 4.6) for analysis and planning. Each plan step runs through the **Executor** (Sonnet 4.6), which delegates simple sub-tasks to the **Aide**. The **Supervisor** reviews each Executor step and Aide task before results are aggregated.
+
+### Review supervisor flags
+
+> After running `orchestrate`, call `get_supervisor_verdicts` with the session ID.
+
+```json
+{ "session_id": "<uuid>", "flagged_only": true }
+```
+
+Returns only the outputs the Supervisor flagged, with specific issues and recommendations.
 
 ### Direct consultation - risk analysis
 
@@ -201,6 +220,7 @@ Use `get_council_state` at any point to inspect a session. Each session tracks:
 - Chancellor plan (if invoked)
 - Executor step results
 - Aide task results
+- Supervisor verdicts (one per Executor step and Aide task)
 - Metrics: total agent calls, agents invoked, duration
 
 ---
@@ -232,6 +252,7 @@ src/
     chancellor/     # Chancellor agent wrapper
     executor/       # Executor agent wrapper
     aide/           # Aide agent wrapper
+    supervisor/     # Supervisor agent wrapper (non-blocking quality review)
   infra/            # External dependencies
     agent-sdk/      # runner.ts - wraps Claude Agent SDK query()
     state/          # In-process session state store (LRU, 500 session cap)
@@ -248,7 +269,7 @@ src/
 1. Bump version in `package.json`.
 2. Update `CHANGELOG.md` - move Unreleased entries under the new version heading.
 3. Tag and push: `git tag vX.Y.Z && git push origin vX.Y.Z`
-4. GitHub Actions builds, creates a GitHub Release, and publishes to npm.
+4. GitHub Actions builds, creates a GitHub Release, and publishes to npm and GitHub Packages.
 
 To enable npm publishing, add your `NPM_TOKEN` as a repository secret under **Settings -> Secrets and variables -> Actions**.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "council-mcp",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Three-tier AI agent MCP orchestration system: Chancellor (Opus), Executor (Sonnet), Aide (Haiku)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What does this PR do?

Release prep for v0.2.0. No code changes — bumps version and updates docs to reflect everything merged since v0.1.2.

## Type of change

- [x] Release / version bump

## Changes

- `package.json` version bumped to `0.2.0`
- `CHANGELOG.md` — Unreleased entries moved under `[0.2.0] - 2026-04-12`
- `README.md` — updated throughout for the Supervisor agent:
  - Intro updated from "three-tier" to "four-tier"
  - Flow diagram updated to show Supervisor in the pipeline
  - Routing table updated to include Supervisor in all paths
  - Agent roles table has Supervisor row
  - Orchestration sequence diagram shows Supervisor after each Executor step and Aide task
  - MCP tools table has `get_supervisor_verdicts`
  - Usage examples section has a Supervisor review example
  - Session lifecycle section lists `supervisor_verdicts`
  - Project structure shows `supervisor/` directory

## Release

After merging, tag to trigger the release workflow:

```
git tag v0.2.0 && git push origin v0.2.0
```
