### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-04-13
+
+### Fixed
+- `install.sh` now also runs `claude mcp add` to register the server with Claude Code CLI — previously only Claude Desktop was configured, so the tools were invisible in the CLI
+- `install.ps1` rewritten to match: detects `claude` binary, falls back to `ANTHROPIC_API_KEY`, configures both Claude Desktop and Claude Code CLI
+- `runner.ts` strips `ANTHROPIC_API_KEY` when set to an empty string — Claude Desktop injects an empty key into the MCP server env, causing the child `claude` process to attempt API key auth and fail with exit 1
+
 ## [0.2.1] - 2026-04-12
 
 ### Fixed
@@ -66,7 +73,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Executor runs with explicit `permissionMode: 'acceptEdits'` rather than relying on inherited default
 - `@anthropic-ai/claude-agent-sdk` pinned to `^0.2.101` (no `latest` in production)
 
-[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/iamvirul/the-council/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/iamvirul/the-council/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/iamvirul/the-council/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/iamvirul/the-council/compare/v0.1.1...v0.1.2

--- a/README.md
+++ b/README.md
@@ -128,13 +128,14 @@ curl -fsSL https://raw.githubusercontent.com/iamvirul/the-council/main/install.s
 irm https://raw.githubusercontent.com/iamvirul/the-council/main/install.ps1 | iex
 ```
 
-Both scripts detect your `claude` CLI location and add it to the MCP server's PATH. No API key or extra cost if you already have Claude Code. Nothing is installed globally.
+Both scripts detect your `claude` CLI location and configure both **Claude Desktop** and **Claude Code CLI** automatically. No API key or extra cost if you already have Claude Code. Nothing is installed globally.
 
-| OS | Config file path |
+| Target | Config location |
 |---|---|
-| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
-| Linux | `~/.config/Claude/claude_desktop_config.json` |
-| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Claude Desktop (macOS) | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Claude Desktop (Linux) | `~/.config/Claude/claude_desktop_config.json` |
+| Claude Desktop (Windows) | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Claude Code CLI | Registered via `claude mcp add` (project-scoped) |
 
 Restart Claude Code after running the script.
 
@@ -257,7 +258,7 @@ src/
     aide/           # Aide agent wrapper
     supervisor/     # Supervisor agent wrapper (non-blocking quality review)
   infra/            # External dependencies
-    agent-sdk/      # runner.ts - wraps Claude Agent SDK query()
+    agent-sdk/      # runner.ts - spawns claude CLI subprocess for each agent
     state/          # In-process session state store (LRU, 500 session cap)
     logging/        # pino structured logger (stderr only)
   mcp/

--- a/install.ps1
+++ b/install.ps1
@@ -29,40 +29,59 @@ if (-not (Get-Command npx -ErrorAction SilentlyContinue)) {
     Write-Fail "npx is not available. Make sure npm is installed alongside Node.js."
 }
 
-# ─── API key ─────────────────────────────────────────────────────────────────
-# council-mcp spawns sub-agents via the Anthropic API and needs its own key.
-# It cannot inherit Claude Code's session credentials.
+# ─── Find claude binary ───────────────────────────────────────────────────────
+# council-mcp spawns sub-agents via the claude CLI — no separate API key needed
+# if Claude Code is already installed.
 
-Write-Host ""
-Write-Info "council-mcp requires an Anthropic API key to spawn sub-agents."
-Write-Host "Get one at https://console.anthropic.com"
-Write-Host ""
+$ClaudePath = $null
 
-$ApiKey = $env:ANTHROPIC_API_KEY
+$candidates = @(
+    "$env:LOCALAPPDATA\Programs\claude\claude.exe",
+    "$env:LOCALAPPDATA\AnthropicClaude\claude.exe",
+    (Get-Command claude -ErrorAction SilentlyContinue)?.Source
+)
 
-if ($ApiKey) {
-    Write-Host "Found ANTHROPIC_API_KEY in environment."
-} else {
-    $SecureKey = Read-Host "Paste your Anthropic API key" -AsSecureString
-    $ApiKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
-        [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureKey)
-    )
-
-    if (-not $ApiKey) {
-        Write-Fail "No API key provided. Re-run the script and enter your key, or set ANTHROPIC_API_KEY before running."
+foreach ($c in $candidates) {
+    if ($c -and (Test-Path $c)) {
+        $ClaudePath = $c
+        break
     }
 }
 
-# ─── Find Claude config file ─────────────────────────────────────────────────
+$AuthMode = 'session'
+$ApiKey   = $env:ANTHROPIC_API_KEY
+
+if ($ClaudePath) {
+    Write-Host "Found claude CLI at: $ClaudePath"
+    Write-Host "Using existing Claude Code session (no API key needed)."
+} elseif ($ApiKey) {
+    $AuthMode = 'api_key'
+    Write-Host "claude CLI not found — using ANTHROPIC_API_KEY."
+} else {
+    Write-Host "claude CLI not found in common locations." -ForegroundColor Yellow
+    Write-Host "If Claude Code is installed, add its directory to PATH and re-run."
+    Write-Host "Or set ANTHROPIC_API_KEY to use API key auth instead."
+    $SecureKey = Read-Host "Paste your Anthropic API key (or press Enter to skip)" -AsSecureString
+    $ApiKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+        [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureKey)
+    )
+    if ($ApiKey) {
+        $AuthMode = 'api_key'
+    } else {
+        Write-Fail "No claude CLI or API key available. Cannot configure The Council."
+    }
+}
+
+$ClaudeDir = if ($ClaudePath) { Split-Path $ClaudePath } else { $null }
+$McpPath   = if ($ClaudeDir) { "$ClaudeDir;$env:SystemRoot\System32" } else { $null }
+
+# ─── 1. Claude Desktop config ────────────────────────────────────────────────
 
 $ConfigDir  = Join-Path $env:APPDATA 'Claude'
 $ConfigFile = Join-Path $ConfigDir 'claude_desktop_config.json'
 
-# ─── Merge MCP server entry into config ──────────────────────────────────────
+Write-Info "Configuring Claude Desktop MCP server..."
 
-Write-Info "Configuring Claude MCP server..."
-
-# Read existing config or start empty
 if (Test-Path $ConfigFile) {
     try {
         $config = Get-Content $ConfigFile -Raw | ConvertFrom-Json -AsHashtable
@@ -75,29 +94,49 @@ if (Test-Path $ConfigFile) {
     $config = @{}
 }
 
-# Ensure mcpServers key exists
 if (-not $config.ContainsKey('mcpServers')) {
     $config['mcpServers'] = @{}
 }
 
-if ($config['mcpServers'].ContainsKey($ServerKey)) {
-    Write-Host "Already configured: `"$ServerKey`" entry exists - updating." -ForegroundColor Yellow
+$env_block = if ($AuthMode -eq 'api_key') {
+    [ordered]@{ ANTHROPIC_API_KEY = $ApiKey }
+} else {
+    [ordered]@{ PATH = $McpPath }
 }
 
-# Set the server entry with API key in env
 $config['mcpServers'][$ServerKey] = [ordered]@{
     command = 'npx'
     args    = @('-y', $Package)
-    env     = [ordered]@{ ANTHROPIC_API_KEY = $ApiKey }
+    env     = $env_block
 }
 
-# Write back
 if (-not (Test-Path $ConfigDir)) {
     New-Item -ItemType Directory -Path $ConfigDir -Force | Out-Null
 }
 
 $config | ConvertTo-Json -Depth 10 | Set-Content $ConfigFile -Encoding UTF8
-Write-Host "Config written to: $ConfigFile"
+Write-Host "  Desktop config : $ConfigFile"
+
+# ─── 2. Claude Code CLI config ───────────────────────────────────────────────
+
+Write-Info "Configuring Claude Code CLI MCP server..."
+
+$ClaudeCmd = if ($ClaudePath) { $ClaudePath } elseif (Get-Command claude -ErrorAction SilentlyContinue) { 'claude' } else { $null }
+
+if ($ClaudeCmd) {
+    try {
+        if ($AuthMode -eq 'api_key') {
+            & $ClaudeCmd mcp add $ServerKey -e "ANTHROPIC_API_KEY=$ApiKey" -- npx -y $Package 2>$null
+        } else {
+            & $ClaudeCmd mcp add $ServerKey -e "PATH=$McpPath" -- npx -y $Package 2>$null
+        }
+        Write-Host "  CLI config     : registered via 'claude mcp add'"
+    } catch {
+        Write-Host "  CLI config     : skipped (already registered or claude mcp add failed)"
+    }
+} else {
+    Write-Host "  CLI config     : skipped (claude CLI not found)"
+}
 
 # ─── Done ─────────────────────────────────────────────────────────────────────
 
@@ -106,7 +145,7 @@ Write-Host "The Council is configured." -ForegroundColor White -BackgroundColor 
 Write-Host ""
 Write-Host "  Server key : $ServerKey"
 Write-Host "  Package    : $Package (runs via npx, no global install needed)"
-Write-Host "  Config     : $ConfigFile"
+Write-Host "  Auth       : $AuthMode"
 Write-Host ""
 Write-Ok "Restart Claude Code and the council tools will appear automatically."
 Write-Host ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "council-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Three-tier AI agent MCP orchestration system: Chancellor (Opus), Executor (Sonnet), Aide (Haiku)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What does this PR do?

Version bump and release prep for v0.2.2.

## Type of change

- [x] Release / version bump

## Changes

- `package.json` → `0.2.2`
- `CHANGELOG.md` — v0.2.2 entries
- `README.md` — updated install table to show both Desktop and CLI targets; fixed project structure comment
- `install.ps1` — rewritten to match `install.sh`: detects claude binary, falls back to API key, configures both Claude Desktop and Claude Code CLI via `claude mcp add`

## Checklist

- [x] `npm run build` passes
- [x] No secrets, credentials, or hardcoded values introduced
- [x] CHANGELOG.md updated