### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-04-13
+
+### Changed
+- README diagrams replaced with hosted images — architecture, orchestration flow, and session lifecycle diagrams now render correctly on all platforms including GitHub, npm, and PyPI mirrors
+
 ## [0.2.2] - 2026-04-13
 
 ### Fixed
@@ -73,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Executor runs with explicit `permissionMode: 'acceptEdits'` rather than relying on inherited default
 - `@anthropic-ai/claude-agent-sdk` pinned to `^0.2.101` (no `latest` in production)
 
-[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/iamvirul/the-council/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/iamvirul/the-council/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/iamvirul/the-council/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/iamvirul/the-council/compare/v0.1.2...v0.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "council-mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Three-tier AI agent MCP orchestration system: Chancellor (Opus), Executor (Sonnet), Aide (Haiku)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What does this PR do?

Version bump for v0.2.3 — README diagram images.

## Type of change

- [x] Release / version bump
- [x] Documentation

## Changes

- `package.json` → `0.2.3`
- `CHANGELOG.md` — v0.2.3 entry added
- README mermaid diagrams replaced with hosted images (merged separately in #15)

## Checklist

- [x] `npm run build` passes
- [x] No secrets, credentials, or hardcoded values introduced
- [x] CHANGELOG.md updated