### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Type-check & Build


### PR DESCRIPTION
Potential fix for [https://github.com/iamvirul/the-council/security/code-scanning/1](https://github.com/iamvirul/the-council/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (recommended here since both jobs appear to need only read access). The minimal safe baseline for this workflow is:

- `contents: read`

This allows `actions/checkout` and common read-only operations while preventing unnecessary write scopes. No functional behavior should change for the shown steps.

**Where to change:**
- File: `.github/workflows/ci.yml`
- Insert `permissions:` after the `concurrency` block and before `jobs:`.

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
