### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 concurrency:
   group: pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/iamvirul/the-council/security/code-scanning/2](https://github.com/iamvirul/the-council/security/code-scanning/2)

Add an explicit `permissions` block to the workflow root so all jobs inherit least-privilege defaults. For this workflow, `contents: read` is the appropriate minimal permission and preserves existing functionality (checkout and read-only CI tasks).  

Change file: **`.github/workflows/pr-check.yml`**  
- Insert `permissions:` after the `on:` section (or before `jobs:`), with:
  - `contents: read`

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
