### PR TITLE
feat: persistent session memory (file + SQLite backends)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-18
+
+### Added
+- **Persistent session memory** — sessions now survive MCP server restarts via an optional `COUNCIL_PERSIST` env var:
+  - `memory` (default) — in-process LRU Map, no breaking change
+  - `file` — JSON files at `~/.council/sessions/<id>.json`, zero dependencies
+  - `sqlite` — SQLite at `~/.council/council.db` via `better-sqlite3`, WAL mode for safe concurrent access
+- **`SessionStore` interface** — all backends implement a common contract; swappable without touching orchestration code
+- **7-day session TTL** — file and SQLite backends auto-expire sessions older than 7 days on startup
+- **Startup validation** — unknown `COUNCIL_PERSIST` values emit a warning and fall back to memory
+
 ## [0.2.3] - 2026-04-13
 
 ### Changed
@@ -78,7 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Executor runs with explicit `permissionMode: 'acceptEdits'` rather than relying on inherited default
 - `@anthropic-ai/claude-agent-sdk` pinned to `^0.2.101` (no `latest` in production)
 
-[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/iamvirul/the-council/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/iamvirul/the-council/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/iamvirul/the-council/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/iamvirul/the-council/compare/v0.2.0...v0.2.1

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ By default sessions are stored in memory and cleared when the MCP server restart
 }
 ```
 
-Sessions are automatically expired after 7 days in file and SQLite modes.
+Sessions older than 7 days are automatically expired on startup and periodically in file and SQLite modes.
 
 ### Registries
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,33 @@ If you prefer API key auth instead, use `"ANTHROPIC_API_KEY": "sk-ant-..."` in t
 
 Restart Claude Code and the tools will appear.
 
+### Persistent sessions (optional)
+
+By default sessions are stored in memory and cleared when the MCP server restarts. To persist sessions across restarts, add `COUNCIL_PERSIST` to the env block:
+
+| Value | Storage | Notes |
+|---|---|---|
+| `memory` | In-process (default) | Cleared on restart, no setup needed |
+| `file` | `~/.council/sessions/<id>.json` | Zero dependencies, human-readable |
+| `sqlite` | `~/.council/council.db` | Recommended — fast, transactional, concurrent-safe |
+
+```json
+{
+  "mcpServers": {
+    "the-council": {
+      "command": "npx",
+      "args": ["-y", "council-mcp"],
+      "env": {
+        "PATH": "/path/to/claude/bin:/usr/local/bin:/usr/bin:/bin",
+        "COUNCIL_PERSIST": "sqlite"
+      }
+    }
+  }
+}
+```
+
+Sessions are automatically expired after 7 days in file and SQLite modes.
+
 ### Registries
 
 The package is published to two registries on every release:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
-  "name": "the-council",
+  "name": "council-mcp",
   "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "the-council",
+      "name": "council-mcp",
       "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.101",
         "@modelcontextprotocol/sdk": "^1.9.0",
+        "better-sqlite3": "^12.9.0",
         "pino": "^9.6.0",
         "zod": "^4.0.0"
       },
@@ -18,6 +19,7 @@
         "the-council": "dist/index.js"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^3.1.0",
         "pino-pretty": "^13.0.0",
@@ -1391,6 +1393,16 @@
         "win32"
       ]
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1422,6 +1434,7 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1688,6 +1701,60 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -1723,6 +1790,30 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {
@@ -1799,6 +1890,12 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -1925,6 +2022,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1935,6 +2047,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1942,6 +2063,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -1991,7 +2121,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -2122,6 +2251,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2137,6 +2275,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2247,6 +2386,12 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2302,6 +2447,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2376,6 +2527,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -2490,6 +2647,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2537,10 +2695,36 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -2811,6 +2995,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -2831,7 +3027,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2846,6 +3041,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2872,6 +3073,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -2879,6 +3086,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/object-assign": {
@@ -3014,6 +3233,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3131,6 +3351,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -3164,7 +3411,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -3214,6 +3460,44 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/real-require": {
@@ -3305,6 +3589,26 @@
         "node": ">= 18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -3341,7 +3645,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3514,6 +3817,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -3564,6 +3912,15 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -3715,6 +4072,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
@@ -3821,6 +4206,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3833,6 +4219,18 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-is": {
@@ -3879,6 +4277,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -3894,6 +4298,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3992,6 +4397,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -4200,6 +4606,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1434,7 +1434,6 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2275,7 +2274,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2647,7 +2645,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3233,7 +3230,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4206,7 +4202,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4298,7 +4293,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4397,7 +4391,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -4606,7 +4599,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -51,10 +51,12 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.101",
     "@modelcontextprotocol/sdk": "^1.9.0",
+    "better-sqlite3": "^12.9.0",
     "pino": "^9.6.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.1.0",
     "pino-pretty": "^13.0.0",

--- a/src/domain/models/types.ts
+++ b/src/domain/models/types.ts
@@ -98,7 +98,8 @@ export type CouncilErrorCode =
   | 'SESSION_NOT_FOUND'
   | 'ORCHESTRATION_FAILED'
   | 'AGENT_PARSE_ERROR'
-  | 'SUPERVISOR_ERROR';
+  | 'SUPERVISOR_ERROR'
+  | 'SESSION_PARSE_ERROR';
 
 export class CouncilError extends Error {
   constructor(

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,15 @@ if (!process.env['ANTHROPIC_API_KEY'] && !findClaude()) {
   process.exit(1);
 }
 
+// Validate COUNCIL_PERSIST value early so misconfiguration fails fast.
+const persistMode = (process.env['COUNCIL_PERSIST'] ?? 'memory').toLowerCase();
+if (!['memory', 'file', 'sqlite'].includes(persistMode)) {
+  process.stderr.write(
+    `Warning: unknown COUNCIL_PERSIST="${persistMode}" — falling back to memory.\n` +
+    `Valid values: memory | file | sqlite\n`,
+  );
+}
+
 import { startServer } from './mcp/server/index.js';
 
 startServer().catch((err: unknown) => {

--- a/src/infra/state/council-state.ts
+++ b/src/infra/state/council-state.ts
@@ -16,6 +16,13 @@ export type { SessionStore };
 // createRequire lets us synchronously load CJS-compatible modules inside ESM.
 const require = createRequire(import.meta.url);
 
+/**
+ * Selects and constructs the process-wide session store implementation based on the COUNCIL_PERSIST environment variable.
+ *
+ * If COUNCIL_PERSIST is 'file' or 'sqlite' the corresponding persistent store is returned; otherwise the in-memory store is returned (default: 'memory').
+ *
+ * @returns A `SessionStore` instance configured for the selected persistence mode ('memory', 'file', or 'sqlite').
+ */
 function createStore(): SessionStore {
   const mode = (process.env['COUNCIL_PERSIST'] ?? 'memory').toLowerCase();
 

--- a/src/infra/state/council-state.ts
+++ b/src/infra/state/council-state.ts
@@ -20,15 +20,25 @@ function createStore(): SessionStore {
   const mode = (process.env['COUNCIL_PERSIST'] ?? 'memory').toLowerCase();
 
   if (mode === 'file') {
-    const { FileStore } = require('./stores/file-store.js') as typeof import('./stores/file-store.js');
-    logger.info({ mode: 'file' }, 'Session persistence: file (~/.council/sessions/)');
-    return new FileStore();
+    try {
+      const { FileStore } = require('./stores/file-store.js') as typeof import('./stores/file-store.js');
+      logger.info({ mode: 'file' }, 'Session persistence: file (~/.council/sessions/)');
+      return new FileStore();
+    } catch (err) {
+      logger.error({ mode: 'file', path: '~/.council/sessions/', err }, 'FileStore initialization failed — falling back to memory');
+      return new MemoryStore();
+    }
   }
 
   if (mode === 'sqlite') {
-    const { SQLiteStore } = require('./stores/sqlite-store.js') as typeof import('./stores/sqlite-store.js');
-    logger.info({ mode: 'sqlite' }, 'Session persistence: SQLite (~/.council/council.db)');
-    return new SQLiteStore();
+    try {
+      const { SQLiteStore } = require('./stores/sqlite-store.js') as typeof import('./stores/sqlite-store.js');
+      logger.info({ mode: 'sqlite' }, 'Session persistence: SQLite (~/.council/council.db)');
+      return new SQLiteStore();
+    } catch (err) {
+      logger.error({ mode: 'sqlite', path: '~/.council/council.db', err }, 'SQLiteStore initialization failed — falling back to memory');
+      return new MemoryStore();
+    }
   }
 
   if (mode !== 'memory') {

--- a/src/infra/state/council-state.ts
+++ b/src/infra/state/council-state.ts
@@ -1,116 +1,44 @@
-// In-memory session store. Sessions live for the lifetime of the MCP server process.
-import type { CouncilSession, AgentRole, ExecutorResponse, AideResponse, SessionPhase, ChancellorResponse, SupervisorVerdict } from '../../domain/models/types.js';
-import { CouncilError } from '../../domain/models/types.js';
+// Session store factory — selects backend based on COUNCIL_PERSIST env var.
+//
+//   COUNCIL_PERSIST=memory  (default) — in-process LRU Map, cleared on restart
+//   COUNCIL_PERSIST=file             — JSON files at ~/.council/sessions/
+//   COUNCIL_PERSIST=sqlite           — SQLite at ~/.council/council.db
+//
+// The exported `stateStore` is a drop-in replacement for the old singleton.
+// All call sites are unchanged.
+import { createRequire } from 'module';
+import type { SessionStore } from './session-store.js';
+import { MemoryStore } from './stores/memory-store.js';
+import { logger } from '../logging/logger.js';
 
-// Cap at 500 sessions — evict oldest when exceeded to prevent OOM.
-const MAX_SESSIONS = 500;
+export type { SessionStore };
 
-class CouncilStateStore {
-  private sessions = new Map<string, CouncilSession>();
+// createRequire lets us synchronously load CJS-compatible modules inside ESM.
+const require = createRequire(import.meta.url);
 
-  create(problem: string): CouncilSession {
-    if (this.sessions.size >= MAX_SESSIONS) {
-      const oldest = [...this.sessions.values()].sort(
-        (a, b) => a.created_at.localeCompare(b.created_at),
-      )[0];
-      if (oldest) this.sessions.delete(oldest.request_id);
-    }
+function createStore(): SessionStore {
+  const mode = (process.env['COUNCIL_PERSIST'] ?? 'memory').toLowerCase();
 
-    const session: CouncilSession = {
-      request_id: crypto.randomUUID(),
-      created_at: new Date().toISOString(),
-      problem,
-      phase: 'planning',
-      executor_progress: {
-        completed_steps: [],
-        results: [],
-      },
-      aide_results: [],
-      supervisor_verdicts: [],
-      metrics: {
-        total_agent_calls: 0,
-        agents_invoked: [],
-      },
-    };
-    this.sessions.set(session.request_id, session);
-    return session;
+  if (mode === 'file') {
+    const { FileStore } = require('./stores/file-store.js') as typeof import('./stores/file-store.js');
+    logger.info({ mode: 'file' }, 'Session persistence: file (~/.council/sessions/)');
+    return new FileStore();
   }
 
-  get(requestId: string): CouncilSession {
-    const session = this.sessions.get(requestId);
-    if (!session) {
-      throw new CouncilError(
-        `Session not found: ${requestId}`,
-        'SESSION_NOT_FOUND',
-      );
-    }
-    return session;
+  if (mode === 'sqlite') {
+    const { SQLiteStore } = require('./stores/sqlite-store.js') as typeof import('./stores/sqlite-store.js');
+    logger.info({ mode: 'sqlite' }, 'Session persistence: SQLite (~/.council/council.db)');
+    return new SQLiteStore();
   }
 
-  getOptional(requestId: string): CouncilSession | undefined {
-    return this.sessions.get(requestId);
+  if (mode !== 'memory') {
+    logger.warn({ COUNCIL_PERSIST: mode }, 'Unknown COUNCIL_PERSIST value — falling back to memory');
+  } else {
+    logger.info({ mode: 'memory' }, 'Session persistence: memory (cleared on restart)');
   }
 
-  setPhase(requestId: string, phase: SessionPhase): void {
-    const session = this.get(requestId);
-    session.phase = phase;
-  }
-
-  setChancellorPlan(requestId: string, plan: ChancellorResponse): void {
-    const session = this.get(requestId);
-    session.chancellor_plan = plan;
-  }
-
-  setCurrentStep(requestId: string, stepId: string): void {
-    const session = this.get(requestId);
-    session.executor_progress.current_step = stepId;
-  }
-
-  recordAgentCall(requestId: string, role: AgentRole): void {
-    const session = this.get(requestId);
-    session.metrics.total_agent_calls++;
-    if (!session.metrics.agents_invoked.includes(role)) {
-      session.metrics.agents_invoked.push(role);
-    }
-  }
-
-  recordExecutorResult(requestId: string, result: ExecutorResponse): void {
-    const session = this.get(requestId);
-    session.executor_progress.results.push(result);
-    session.executor_progress.completed_steps.push(result.step_id);
-    session.executor_progress.current_step = result.next_step;
-  }
-
-  recordAideResult(requestId: string, result: AideResponse): void {
-    const session = this.get(requestId);
-    session.aide_results.push(result);
-  }
-
-  recordSupervisorVerdict(requestId: string, verdict: SupervisorVerdict): void {
-    const session = this.get(requestId);
-    session.supervisor_verdicts.push(verdict);
-  }
-
-  complete(requestId: string, startedAt: number): void {
-    const session = this.get(requestId);
-    session.phase = 'complete';
-    session.metrics.duration_ms = Date.now() - startedAt;
-  }
-
-  fail(requestId: string, startedAt: number): void {
-    const session = this.get(requestId);
-    session.phase = 'failed';
-    session.metrics.duration_ms = Date.now() - startedAt;
-  }
-
-  list(): CouncilSession[] {
-    return Array.from(this.sessions.values());
-  }
-
-  delete(requestId: string): void {
-    this.sessions.delete(requestId);
-  }
+  return new MemoryStore();
 }
 
-// Singleton — one store per process lifetime.
-export const stateStore = new CouncilStateStore();
+// Singleton — one store per process.
+export const stateStore: SessionStore = createStore();

--- a/src/infra/state/session-store.ts
+++ b/src/infra/state/session-store.ts
@@ -1,0 +1,31 @@
+// SessionStore interface — all persistence backends implement this contract.
+// Switch backends via the COUNCIL_PERSIST env var:
+//   unset | "memory"  → in-process LRU Map (default, no setup needed)
+//   "file"            → JSON files at ~/.council/sessions/<id>.json
+//   "sqlite"          → SQLite at ~/.council/council.db
+import type {
+  CouncilSession,
+  AgentRole,
+  ExecutorResponse,
+  AideResponse,
+  SessionPhase,
+  ChancellorResponse,
+  SupervisorVerdict,
+} from '../../domain/models/types.js';
+
+export interface SessionStore {
+  create(problem: string): CouncilSession;
+  get(requestId: string): CouncilSession;
+  getOptional(requestId: string): CouncilSession | undefined;
+  setPhase(requestId: string, phase: SessionPhase): void;
+  setChancellorPlan(requestId: string, plan: ChancellorResponse): void;
+  setCurrentStep(requestId: string, stepId: string): void;
+  recordAgentCall(requestId: string, role: AgentRole): void;
+  recordExecutorResult(requestId: string, result: ExecutorResponse): void;
+  recordAideResult(requestId: string, result: AideResponse): void;
+  recordSupervisorVerdict(requestId: string, verdict: SupervisorVerdict): void;
+  complete(requestId: string, startedAt: number): void;
+  fail(requestId: string, startedAt: number): void;
+  list(): CouncilSession[];
+  delete(requestId: string): void;
+}

--- a/src/infra/state/session-store.ts
+++ b/src/infra/state/session-store.ts
@@ -28,4 +28,5 @@ export interface SessionStore {
   fail(requestId: string, startedAt: number): void;
   list(): CouncilSession[];
   delete(requestId: string): void;
+  close?(): void;
 }

--- a/src/infra/state/stores/file-store.ts
+++ b/src/infra/state/stores/file-store.ts
@@ -1,0 +1,166 @@
+// File-based JSON session store.
+// Each session is stored as ~/.council/sessions/<session_id>.json
+// Sessions older than SESSION_TTL_DAYS are expired on startup.
+// Enable with: COUNCIL_PERSIST=file
+import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type {
+  CouncilSession,
+  AgentRole,
+  ExecutorResponse,
+  AideResponse,
+  SessionPhase,
+  ChancellorResponse,
+  SupervisorVerdict,
+} from '../../../domain/models/types.js';
+import { CouncilError } from '../../../domain/models/types.js';
+import type { SessionStore } from '../session-store.js';
+import { logger } from '../../logging/logger.js';
+
+const SESSION_TTL_DAYS = 7;
+const SESSIONS_DIR = join(homedir(), '.council', 'sessions');
+
+export class FileStore implements SessionStore {
+  private cache = new Map<string, CouncilSession>();
+
+  constructor() {
+    mkdirSync(SESSIONS_DIR, { recursive: true });
+    this.loadAll();
+    this.expireOld();
+    logger.info({ dir: SESSIONS_DIR, sessions: this.cache.size }, 'FileStore initialised');
+  }
+
+  private sessionPath(requestId: string): string {
+    return join(SESSIONS_DIR, `${requestId}.json`);
+  }
+
+  private persist(session: CouncilSession): void {
+    try {
+      writeFileSync(this.sessionPath(session.request_id), JSON.stringify(session, null, 2), 'utf8');
+    } catch (err) {
+      logger.error({ requestId: session.request_id, err }, 'FileStore: failed to write session');
+    }
+  }
+
+  private loadAll(): void {
+    if (!existsSync(SESSIONS_DIR)) return;
+    for (const file of readdirSync(SESSIONS_DIR)) {
+      if (!file.endsWith('.json')) continue;
+      try {
+        const raw = readFileSync(join(SESSIONS_DIR, file), 'utf8');
+        const session = JSON.parse(raw) as CouncilSession;
+        this.cache.set(session.request_id, session);
+      } catch {
+        // Corrupt file — skip silently
+      }
+    }
+  }
+
+  private expireOld(): void {
+    const cutoff = Date.now() - SESSION_TTL_DAYS * 24 * 60 * 60 * 1000;
+    let expired = 0;
+    for (const session of this.cache.values()) {
+      if (new Date(session.created_at).getTime() < cutoff) {
+        this.cache.delete(session.request_id);
+        try { unlinkSync(this.sessionPath(session.request_id)); } catch { /* already gone */ }
+        expired++;
+      }
+    }
+    if (expired > 0) logger.info({ expired }, 'FileStore: expired old sessions');
+  }
+
+  create(problem: string): CouncilSession {
+    const session: CouncilSession = {
+      request_id: crypto.randomUUID(),
+      created_at: new Date().toISOString(),
+      problem,
+      phase: 'planning',
+      executor_progress: { completed_steps: [], results: [] },
+      aide_results: [],
+      supervisor_verdicts: [],
+      metrics: { total_agent_calls: 0, agents_invoked: [] },
+    };
+    this.cache.set(session.request_id, session);
+    this.persist(session);
+    return session;
+  }
+
+  get(requestId: string): CouncilSession {
+    const session = this.cache.get(requestId);
+    if (!session) throw new CouncilError(`Session not found: ${requestId}`, 'SESSION_NOT_FOUND');
+    return session;
+  }
+
+  getOptional(requestId: string): CouncilSession | undefined {
+    return this.cache.get(requestId);
+  }
+
+  setPhase(requestId: string, phase: SessionPhase): void {
+    const s = this.get(requestId);
+    s.phase = phase;
+    this.persist(s);
+  }
+
+  setChancellorPlan(requestId: string, plan: ChancellorResponse): void {
+    const s = this.get(requestId);
+    s.chancellor_plan = plan;
+    this.persist(s);
+  }
+
+  setCurrentStep(requestId: string, stepId: string): void {
+    const s = this.get(requestId);
+    s.executor_progress.current_step = stepId;
+    this.persist(s);
+  }
+
+  recordAgentCall(requestId: string, role: AgentRole): void {
+    const s = this.get(requestId);
+    s.metrics.total_agent_calls++;
+    if (!s.metrics.agents_invoked.includes(role)) s.metrics.agents_invoked.push(role);
+    this.persist(s);
+  }
+
+  recordExecutorResult(requestId: string, result: ExecutorResponse): void {
+    const s = this.get(requestId);
+    s.executor_progress.results.push(result);
+    s.executor_progress.completed_steps.push(result.step_id);
+    s.executor_progress.current_step = result.next_step;
+    this.persist(s);
+  }
+
+  recordAideResult(requestId: string, result: AideResponse): void {
+    const s = this.get(requestId);
+    s.aide_results.push(result);
+    this.persist(s);
+  }
+
+  recordSupervisorVerdict(requestId: string, verdict: SupervisorVerdict): void {
+    const s = this.get(requestId);
+    s.supervisor_verdicts.push(verdict);
+    this.persist(s);
+  }
+
+  complete(requestId: string, startedAt: number): void {
+    const s = this.get(requestId);
+    s.phase = 'complete';
+    s.metrics.duration_ms = Date.now() - startedAt;
+    this.persist(s);
+  }
+
+  fail(requestId: string, startedAt: number): void {
+    const s = this.get(requestId);
+    s.phase = 'failed';
+    s.metrics.duration_ms = Date.now() - startedAt;
+    this.persist(s);
+  }
+
+  list(): CouncilSession[] {
+    return Array.from(this.cache.values());
+  }
+
+  delete(requestId: string): void {
+    this.cache.delete(requestId);
+    try { unlinkSync(this.sessionPath(requestId)); } catch { /* already gone */ }
+  }
+}

--- a/src/infra/state/stores/file-store.ts
+++ b/src/infra/state/stores/file-store.ts
@@ -2,7 +2,7 @@
 // Each session is stored as ~/.council/sessions/<session_id>.json
 // Sessions older than SESSION_TTL_DAYS are expired on startup.
 // Enable with: COUNCIL_PERSIST=file
-import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, unlinkSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, unlinkSync, renameSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import type {
@@ -19,6 +19,7 @@ import type { SessionStore } from '../session-store.js';
 import { logger } from '../../logging/logger.js';
 
 const SESSION_TTL_DAYS = 7;
+const MAX_SESSIONS = 500;
 const SESSIONS_DIR = join(homedir(), '.council', 'sessions');
 
 export class FileStore implements SessionStore {
@@ -28,6 +29,7 @@ export class FileStore implements SessionStore {
     mkdirSync(SESSIONS_DIR, { recursive: true });
     this.loadAll();
     this.expireOld();
+    setInterval(() => this.expireOld(), 6 * 60 * 60 * 1000).unref();
     logger.info({ dir: SESSIONS_DIR, sessions: this.cache.size }, 'FileStore initialised');
   }
 
@@ -37,7 +39,10 @@ export class FileStore implements SessionStore {
 
   private persist(session: CouncilSession): void {
     try {
-      writeFileSync(this.sessionPath(session.request_id), JSON.stringify(session, null, 2), 'utf8');
+      const sessionPath = this.sessionPath(session.request_id);
+      const tmpPath = sessionPath + '.tmp';
+      writeFileSync(tmpPath, JSON.stringify(session, null, 2), 'utf8');
+      renameSync(tmpPath, sessionPath);
     } catch (err) {
       logger.error({ requestId: session.request_id, err }, 'FileStore: failed to write session');
     }
@@ -50,9 +55,13 @@ export class FileStore implements SessionStore {
       try {
         const raw = readFileSync(join(SESSIONS_DIR, file), 'utf8');
         const session = JSON.parse(raw) as CouncilSession;
-        this.cache.set(session.request_id, session);
-      } catch {
-        // Corrupt file — skip silently
+        if (session.request_id) {
+          this.cache.set(session.request_id, session);
+        } else {
+          logger.warn({ file }, 'FileStore: skipping session file with missing request_id');
+        }
+      } catch (err) {
+        logger.warn({ file, err }, 'FileStore: skipping corrupt session file');
       }
     }
   }
@@ -71,6 +80,16 @@ export class FileStore implements SessionStore {
   }
 
   create(problem: string): CouncilSession {
+    if (this.cache.size >= MAX_SESSIONS) {
+      const oldest = [...this.cache.values()].sort(
+        (a, b) => a.created_at.localeCompare(b.created_at),
+      )[0];
+      if (oldest) {
+        this.cache.delete(oldest.request_id);
+        try { unlinkSync(this.sessionPath(oldest.request_id)); } catch { /* already gone */ }
+      }
+    }
+
     const session: CouncilSession = {
       request_id: crypto.randomUUID(),
       created_at: new Date().toISOString(),

--- a/src/infra/state/stores/memory-store.ts
+++ b/src/infra/state/stores/memory-store.ts
@@ -19,10 +19,8 @@ export class MemoryStore implements SessionStore {
 
   create(problem: string): CouncilSession {
     if (this.sessions.size >= MAX_SESSIONS) {
-      const oldest = [...this.sessions.values()].sort(
-        (a, b) => a.created_at.localeCompare(b.created_at),
-      )[0];
-      if (oldest) this.sessions.delete(oldest.request_id);
+      const oldestKey = this.sessions.keys().next().value;
+      if (oldestKey) this.sessions.delete(oldestKey);
     }
 
     const session: CouncilSession = {
@@ -42,11 +40,18 @@ export class MemoryStore implements SessionStore {
   get(requestId: string): CouncilSession {
     const session = this.sessions.get(requestId);
     if (!session) throw new CouncilError(`Session not found: ${requestId}`, 'SESSION_NOT_FOUND');
+    this.sessions.delete(requestId);
+    this.sessions.set(requestId, session);
     return session;
   }
 
   getOptional(requestId: string): CouncilSession | undefined {
-    return this.sessions.get(requestId);
+    const session = this.sessions.get(requestId);
+    if (session) {
+      this.sessions.delete(requestId);
+      this.sessions.set(requestId, session);
+    }
+    return session;
   }
 
   setPhase(requestId: string, phase: SessionPhase): void {

--- a/src/infra/state/stores/memory-store.ts
+++ b/src/infra/state/stores/memory-store.ts
@@ -1,0 +1,104 @@
+// In-memory session store — sessions live for the lifetime of the MCP process.
+// Default backend when COUNCIL_PERSIST is unset.
+import type {
+  CouncilSession,
+  AgentRole,
+  ExecutorResponse,
+  AideResponse,
+  SessionPhase,
+  ChancellorResponse,
+  SupervisorVerdict,
+} from '../../../domain/models/types.js';
+import { CouncilError } from '../../../domain/models/types.js';
+import type { SessionStore } from '../session-store.js';
+
+const MAX_SESSIONS = 500;
+
+export class MemoryStore implements SessionStore {
+  private sessions = new Map<string, CouncilSession>();
+
+  create(problem: string): CouncilSession {
+    if (this.sessions.size >= MAX_SESSIONS) {
+      const oldest = [...this.sessions.values()].sort(
+        (a, b) => a.created_at.localeCompare(b.created_at),
+      )[0];
+      if (oldest) this.sessions.delete(oldest.request_id);
+    }
+
+    const session: CouncilSession = {
+      request_id: crypto.randomUUID(),
+      created_at: new Date().toISOString(),
+      problem,
+      phase: 'planning',
+      executor_progress: { completed_steps: [], results: [] },
+      aide_results: [],
+      supervisor_verdicts: [],
+      metrics: { total_agent_calls: 0, agents_invoked: [] },
+    };
+    this.sessions.set(session.request_id, session);
+    return session;
+  }
+
+  get(requestId: string): CouncilSession {
+    const session = this.sessions.get(requestId);
+    if (!session) throw new CouncilError(`Session not found: ${requestId}`, 'SESSION_NOT_FOUND');
+    return session;
+  }
+
+  getOptional(requestId: string): CouncilSession | undefined {
+    return this.sessions.get(requestId);
+  }
+
+  setPhase(requestId: string, phase: SessionPhase): void {
+    this.get(requestId).phase = phase;
+  }
+
+  setChancellorPlan(requestId: string, plan: ChancellorResponse): void {
+    this.get(requestId).chancellor_plan = plan;
+  }
+
+  setCurrentStep(requestId: string, stepId: string): void {
+    this.get(requestId).executor_progress.current_step = stepId;
+  }
+
+  recordAgentCall(requestId: string, role: AgentRole): void {
+    const s = this.get(requestId);
+    s.metrics.total_agent_calls++;
+    if (!s.metrics.agents_invoked.includes(role)) s.metrics.agents_invoked.push(role);
+  }
+
+  recordExecutorResult(requestId: string, result: ExecutorResponse): void {
+    const s = this.get(requestId);
+    s.executor_progress.results.push(result);
+    s.executor_progress.completed_steps.push(result.step_id);
+    s.executor_progress.current_step = result.next_step;
+  }
+
+  recordAideResult(requestId: string, result: AideResponse): void {
+    this.get(requestId).aide_results.push(result);
+  }
+
+  recordSupervisorVerdict(requestId: string, verdict: SupervisorVerdict): void {
+    this.get(requestId).supervisor_verdicts.push(verdict);
+  }
+
+  complete(requestId: string, startedAt: number): void {
+    const s = this.get(requestId);
+    s.phase = 'complete';
+    s.metrics.duration_ms = Date.now() - startedAt;
+  }
+
+  fail(requestId: string, startedAt: number): void {
+    const s = this.get(requestId);
+    s.phase = 'failed';
+    s.metrics.duration_ms = Date.now() - startedAt;
+  }
+
+  list(): CouncilSession[] {
+    return Array.from(this.sessions.values());
+  }
+
+  delete(requestId: string): void {
+    this.sessions.delete(requestId);
+  }
+}

--- a/src/infra/state/stores/sqlite-store.ts
+++ b/src/infra/state/stores/sqlite-store.ts
@@ -25,6 +25,7 @@ const DB_PATH = join(DB_DIR, 'council.db');
 
 export class SQLiteStore implements SessionStore {
   private db: Database.Database;
+  private expirationTimer?: NodeJS.Timeout;
 
   constructor() {
     mkdirSync(DB_DIR, { recursive: true });
@@ -33,6 +34,8 @@ export class SQLiteStore implements SessionStore {
     this.db.pragma('foreign_keys = ON');
     this.bootstrap();
     this.expireOld();
+    this.expirationTimer = setInterval(() => this.expireOld(), 24 * 60 * 60 * 1000);
+    this.expirationTimer.unref();
     const count = (this.db.prepare('SELECT COUNT(*) as n FROM sessions').get() as { n: number }).n;
     logger.info({ db: DB_PATH, sessions: count }, 'SQLiteStore initialised');
   }
@@ -67,8 +70,17 @@ export class SQLiteStore implements SessionStore {
   }
 
   private read(requestId: string): CouncilSession | undefined {
-    const row = this.db.prepare('SELECT data FROM sessions WHERE id = ?').get(requestId) as { data: string } | undefined;
-    return row ? JSON.parse(row.data) as CouncilSession : undefined;
+    const cutoff = new Date(Date.now() - SESSION_TTL_DAYS * 24 * 60 * 60 * 1000).toISOString();
+    const row = this.db.prepare('SELECT data, created_at FROM sessions WHERE id = ? AND created_at >= ?').get(requestId, cutoff) as { data: string; created_at: string } | undefined;
+    if (!row) return undefined;
+    try {
+      return JSON.parse(row.data) as CouncilSession;
+    } catch (err) {
+      throw new CouncilError(
+        `Failed to parse session data for ${requestId}: ${row.data.slice(0, 100)}`,
+        'SESSION_PARSE_ERROR',
+      );
+    }
   }
 
   create(problem: string): CouncilSession {
@@ -156,11 +168,29 @@ export class SQLiteStore implements SessionStore {
   }
 
   list(): CouncilSession[] {
-    const rows = this.db.prepare('SELECT data FROM sessions ORDER BY created_at DESC').all() as { data: string }[];
-    return rows.map(r => JSON.parse(r.data) as CouncilSession);
+    const cutoff = new Date(Date.now() - SESSION_TTL_DAYS * 24 * 60 * 60 * 1000).toISOString();
+    const rows = this.db.prepare('SELECT data, id FROM sessions WHERE created_at >= ? ORDER BY created_at DESC').all(cutoff) as { data: string; id: string }[];
+    const sessions: CouncilSession[] = [];
+    for (const row of rows) {
+      try {
+        sessions.push(JSON.parse(row.data) as CouncilSession);
+      } catch (err) {
+        logger.warn({ id: row.id, err }, 'SQLiteStore: skipping row with corrupt JSON');
+      }
+    }
+    return sessions;
   }
 
   delete(requestId: string): void {
     this.db.prepare('DELETE FROM sessions WHERE id = ?').run(requestId);
+  }
+
+  close(): void {
+    if (this.expirationTimer) {
+      clearInterval(this.expirationTimer);
+      this.expirationTimer = undefined;
+    }
+    this.db.close();
+    logger.info('SQLiteStore closed');
   }
 }

--- a/src/infra/state/stores/sqlite-store.ts
+++ b/src/infra/state/stores/sqlite-store.ts
@@ -1,0 +1,166 @@
+// SQLite session store — sessions persist across MCP server restarts.
+// Stored in ~/.council/council.db (single file, no server needed).
+// Sessions older than SESSION_TTL_DAYS are expired on startup.
+// Enable with: COUNCIL_PERSIST=sqlite
+import Database from 'better-sqlite3';
+import { mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type {
+  CouncilSession,
+  AgentRole,
+  ExecutorResponse,
+  AideResponse,
+  SessionPhase,
+  ChancellorResponse,
+  SupervisorVerdict,
+} from '../../../domain/models/types.js';
+import { CouncilError } from '../../../domain/models/types.js';
+import type { SessionStore } from '../session-store.js';
+import { logger } from '../../logging/logger.js';
+
+const SESSION_TTL_DAYS = 7;
+const DB_DIR  = join(homedir(), '.council');
+const DB_PATH = join(DB_DIR, 'council.db');
+
+export class SQLiteStore implements SessionStore {
+  private db: Database.Database;
+
+  constructor() {
+    mkdirSync(DB_DIR, { recursive: true });
+    this.db = new Database(DB_PATH);
+    this.db.pragma('journal_mode = WAL');  // safe for concurrent readers
+    this.db.pragma('foreign_keys = ON');
+    this.bootstrap();
+    this.expireOld();
+    const count = (this.db.prepare('SELECT COUNT(*) as n FROM sessions').get() as { n: number }).n;
+    logger.info({ db: DB_PATH, sessions: count }, 'SQLiteStore initialised');
+  }
+
+  private bootstrap(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS sessions (
+        id         TEXT PRIMARY KEY,
+        data       TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(created_at);
+    `);
+  }
+
+  private expireOld(): void {
+    const cutoff = new Date(Date.now() - SESSION_TTL_DAYS * 24 * 60 * 60 * 1000).toISOString();
+    const result = this.db.prepare('DELETE FROM sessions WHERE created_at < ?').run(cutoff);
+    if (result.changes > 0) {
+      logger.info({ expired: result.changes }, 'SQLiteStore: expired old sessions');
+    }
+  }
+
+  private write(session: CouncilSession): void {
+    const now = new Date().toISOString();
+    this.db.prepare(`
+      INSERT INTO sessions (id, data, created_at, updated_at)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at
+    `).run(session.request_id, JSON.stringify(session), session.created_at, now);
+  }
+
+  private read(requestId: string): CouncilSession | undefined {
+    const row = this.db.prepare('SELECT data FROM sessions WHERE id = ?').get(requestId) as { data: string } | undefined;
+    return row ? JSON.parse(row.data) as CouncilSession : undefined;
+  }
+
+  create(problem: string): CouncilSession {
+    const session: CouncilSession = {
+      request_id: crypto.randomUUID(),
+      created_at: new Date().toISOString(),
+      problem,
+      phase: 'planning',
+      executor_progress: { completed_steps: [], results: [] },
+      aide_results: [],
+      supervisor_verdicts: [],
+      metrics: { total_agent_calls: 0, agents_invoked: [] },
+    };
+    this.write(session);
+    return session;
+  }
+
+  get(requestId: string): CouncilSession {
+    const session = this.read(requestId);
+    if (!session) throw new CouncilError(`Session not found: ${requestId}`, 'SESSION_NOT_FOUND');
+    return session;
+  }
+
+  getOptional(requestId: string): CouncilSession | undefined {
+    return this.read(requestId);
+  }
+
+  setPhase(requestId: string, phase: SessionPhase): void {
+    const s = this.get(requestId);
+    s.phase = phase;
+    this.write(s);
+  }
+
+  setChancellorPlan(requestId: string, plan: ChancellorResponse): void {
+    const s = this.get(requestId);
+    s.chancellor_plan = plan;
+    this.write(s);
+  }
+
+  setCurrentStep(requestId: string, stepId: string): void {
+    const s = this.get(requestId);
+    s.executor_progress.current_step = stepId;
+    this.write(s);
+  }
+
+  recordAgentCall(requestId: string, role: AgentRole): void {
+    const s = this.get(requestId);
+    s.metrics.total_agent_calls++;
+    if (!s.metrics.agents_invoked.includes(role)) s.metrics.agents_invoked.push(role);
+    this.write(s);
+  }
+
+  recordExecutorResult(requestId: string, result: ExecutorResponse): void {
+    const s = this.get(requestId);
+    s.executor_progress.results.push(result);
+    s.executor_progress.completed_steps.push(result.step_id);
+    s.executor_progress.current_step = result.next_step;
+    this.write(s);
+  }
+
+  recordAideResult(requestId: string, result: AideResponse): void {
+    const s = this.get(requestId);
+    s.aide_results.push(result);
+    this.write(s);
+  }
+
+  recordSupervisorVerdict(requestId: string, verdict: SupervisorVerdict): void {
+    const s = this.get(requestId);
+    s.supervisor_verdicts.push(verdict);
+    this.write(s);
+  }
+
+  complete(requestId: string, startedAt: number): void {
+    const s = this.get(requestId);
+    s.phase = 'complete';
+    s.metrics.duration_ms = Date.now() - startedAt;
+    this.write(s);
+  }
+
+  fail(requestId: string, startedAt: number): void {
+    const s = this.get(requestId);
+    s.phase = 'failed';
+    s.metrics.duration_ms = Date.now() - startedAt;
+    this.write(s);
+  }
+
+  list(): CouncilSession[] {
+    const rows = this.db.prepare('SELECT data FROM sessions ORDER BY created_at DESC').all() as { data: string }[];
+    return rows.map(r => JSON.parse(r.data) as CouncilSession);
+  }
+
+  delete(requestId: string): void {
+    this.db.prepare('DELETE FROM sessions WHERE id = ?').run(requestId);
+  }
+}

--- a/src/mcp/server/index.ts
+++ b/src/mcp/server/index.ts
@@ -50,7 +50,7 @@ export async function startServer(): Promise<void> {
     'orchestrate',
     'Route a problem through The Council. Complex problems invoke the Chancellor for planning then the Executor for implementation. Simple problems go straight to the Executor. Trivial tasks go to the Aide. Returns the full result plus a session ID for follow-up.',
     orchestrateSchema,
-    async ({ problem }) => {
+    async ({ problem }: { problem: string }) => {
       try {
         const result = await orchestrate(problem);
         return {
@@ -68,7 +68,7 @@ export async function startServer(): Promise<void> {
     'consult_chancellor',
     'Invoke the Chancellor (Claude Opus) directly for deep strategic analysis and planning. Returns a structured plan with steps, risks, and delegation guidance.',
     consultChancellorSchema,
-    async ({ problem, context }) => {
+    async ({ problem, context }: { problem: string; context?: string }) => {
       try {
         const response = await invokeChancellor({ problem, context });
         return {
@@ -200,12 +200,14 @@ export async function startServer(): Promise<void> {
 
   process.on('SIGINT', async () => {
     logger.info('Shutting down (SIGINT)');
+    if (stateStore.close) stateStore.close();
     await server.close();
     process.exit(0);
   });
 
   process.on('SIGTERM', async () => {
     logger.info('Shutting down (SIGTERM)');
+    if (stateStore.close) stateStore.close();
     await server.close();
     process.exit(0);
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
## What does this PR do?

Adds optional persistent session storage so sessions survive MCP server restarts. Closes #17.

## Type of change

- [x] New feature

## Changes

- `src/infra/state/session-store.ts` - `SessionStore` interface all backends implement
- `src/infra/state/stores/memory-store.ts` - existing LRU store refactored to implement interface
- `src/infra/state/stores/file-store.ts` - JSON files at `~/.council/sessions/<id>.json`
- `src/infra/state/stores/sqlite-store.ts` - SQLite at `~/.council/council.db` via `better-sqlite3` (WAL mode)
- `src/infra/state/council-state.ts` - factory picks backend from `COUNCIL_PERSIST` env var
- `src/index.ts` - validates `COUNCIL_PERSIST` at startup, warns on unknown values
- `package.json` - added `better-sqlite3` + `@types/better-sqlite3`
- `CHANGELOG.md` / `README.md` - documented persistence options and config example

## Usage

| `COUNCIL_PERSIST` | Backend | Storage |
|---|---|---|
| unset or `memory` | In-process LRU Map | Cleared on restart (default, no breaking change) |
| `file` | JSON files | `~/.council/sessions/<id>.json` |
| `sqlite` | SQLite | `~/.council/council.db` |

Sessions auto-expire after 7 days in file and SQLite backends.

## Test plan

- [x] All three backends tested - all return correct session state
- [x] `npm run build` passes
- [x] No breaking change - default behaviour unchanged

## Checklist

- [x] `npm run type-check` passes
- [x] `npm run build` passes
- [x] No new `any` types or unvalidated external data
- [x] No secrets, credentials, or hardcoded values introduced
- [x] CHANGELOG.md updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional persistent session storage via the `COUNCIL_PERSIST` environment variable with three modes: in-memory (default), file-based JSON, and SQLite database.
  * Sessions automatically expire after 7 days in file and SQLite persistence modes.
  * Sessions can now be retained across application restarts when persistence is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->