### PR TITLE
chore: release v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "council-mcp",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Three-tier AI agent MCP orchestration system: Chancellor (Opus), Executor (Sonnet), Aide (Haiku)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What does this PR do?

Version bump for v0.3.0 — persistent session memory.

## Type of change

- [x] Release / version bump

## Changes

- `package.json` -> `0.3.0`

## Checklist

- [x] `npm run build` passes
- [x] CHANGELOG.md updated