### PR TITLE
feat: give Chancellor and Aide access to MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Per-agent tool access** — Chancellor and Aide now have tool access, configurable via `AGENT_TOOLS` constants:
+  - Chancellor: `Read`, `Glob`, `Grep` (read-only — inspects codebase before planning, never writes)
+  - Executor: `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep` (unchanged)
+  - Aide: `Read` (can read files before transforming them)
+  - Supervisor: none (pure review, no side effects)
+- `AGENT_TOOLS` constant in `src/domain/constants/index.ts` — single source of truth for all per-agent tool sets
+- Chancellor and Aide system prompts updated to describe their tool capabilities and when to use them
+- Removed `runExecutorWithTools` convenience wrapper — Executor now uses `runAgent` + `AGENT_TOOLS.EXECUTOR` directly, consistent with all other agents
 - **Caveman token compression** — reduce internal agent output tokens by 50-60% with no accuracy loss. Inspired by [Caveman](https://github.com/JuliusBrussee/caveman). Set `COUNCIL_CAVEMAN` in the MCP env block:
   - `off` (default) — no compression, unchanged behaviour
   - `lite` — drops filler and pleasantries, keeps grammar (~20% savings)

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Complexity routing uses a fast keyword + word count check with no extra LLM call
 
 | Agent | Model | Role | Tools | Max turns |
 |---|---|---|---|---|
-| **Chancellor** | `claude-opus-4-6` | Deep analysis, planning, risk assessment | None (pure reasoning) | 3 |
+| **Chancellor** | `claude-opus-4-6` | Deep analysis, planning, risk assessment | `Read`, `Glob`, `Grep` (read-only) | 3 |
 | **Executor** | `claude-sonnet-4-6` | Implementation, code, delegation | `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep` | 10 |
-| **Aide** | `claude-haiku-4-5` | Formatting, data transformation, utilities | None (pure reasoning) | 3 |
+| **Aide** | `claude-haiku-4-5` | Formatting, data transformation, utilities | `Read` | 3 |
 | **Supervisor** | `claude-haiku-4-5` | Output review, quality flags, intent alignment | None (pure reasoning) | 2 |
 
 The Supervisor is **advisory only** — it annotates and flags, never blocks. If the Supervisor errors, orchestration continues and a warning is logged.

--- a/src/application/aide/agent.ts
+++ b/src/application/aide/agent.ts
@@ -1,5 +1,5 @@
 import { runAgent } from '../../infra/agent-sdk/runner.js';
-import { AIDE_SYSTEM_PROMPT, MODEL_IDS, MAX_TURNS } from '../../domain/constants/index.js';
+import { AIDE_SYSTEM_PROMPT, MODEL_IDS, MAX_TURNS, AGENT_TOOLS } from '../../domain/constants/index.js';
 import { AideResponseSchema } from '../../domain/models/schemas.js';
 import type { AgentInvokeOptions, AideResponse } from '../../domain/models/types.js';
 import { CouncilError } from '../../domain/models/types.js';
@@ -19,6 +19,7 @@ export async function invokeAide(
     systemPrompt: AIDE_SYSTEM_PROMPT,
     userMessage,
     maxTurns: opts.max_turns ?? MAX_TURNS.AIDE,
+    tools: AGENT_TOOLS.AIDE,
     skipCaveman: opts.skipCaveman,
   });
 

--- a/src/application/aide/agent.ts
+++ b/src/application/aide/agent.ts
@@ -5,6 +5,14 @@ import type { AgentInvokeOptions, AideResponse } from '../../domain/models/types
 import { CouncilError } from '../../domain/models/types.js';
 import { logger } from '../../infra/logging/logger.js';
 
+/**
+ * Invokes the "aide" agent with a constructed user message and returns the parsed, validated response.
+ *
+ * @param taskId - The task identifier included in the agent message
+ * @param opts - Invocation options (`problem`, optional `context`, optional `max_turns`, optional `skipCaveman`)
+ * @returns The validated AideResponse parsed from the agent's JSON output
+ * @throws CouncilError when the agent returns invalid JSON or a value that fails schema validation (code: 'INVALID_JSON_RESPONSE')
+ */
 export async function invokeAide(
   taskId: string,
   opts: AgentInvokeOptions,

--- a/src/application/chancellor/agent.ts
+++ b/src/application/chancellor/agent.ts
@@ -5,6 +5,16 @@ import type { AgentInvokeOptions, ChancellorResponse } from '../../domain/models
 import { CouncilError } from '../../domain/models/types.js';
 import { logger } from '../../infra/logging/logger.js';
 
+/**
+ * Invoke the "chancellor" agent for the given problem, extract JSON from the agent's output,
+ * validate it against the ChancellorResponse schema, and return the parsed response.
+ *
+ * @param opts - Options controlling the invocation. `opts.problem` is the prompt sent to the agent;
+ *               when `opts.context` is present it is appended to the prompt. `opts.max_turns`
+ *               overrides the agent turn limit. `opts.skipCaveman` requests skipping the caveman step.
+ * @returns The validated `ChancellorResponse` produced by the agent.
+ * @throws CouncilError when the agent's output cannot be parsed as JSON or fails schema validation.
+ */
 export async function invokeChancellor(opts: AgentInvokeOptions): Promise<ChancellorResponse> {
   const userMessage = opts.context
     ? `Problem: ${opts.problem}\n\nContext: ${opts.context}`

--- a/src/application/chancellor/agent.ts
+++ b/src/application/chancellor/agent.ts
@@ -1,5 +1,5 @@
 import { runAgent } from '../../infra/agent-sdk/runner.js';
-import { CHANCELLOR_SYSTEM_PROMPT, MODEL_IDS, MAX_TURNS } from '../../domain/constants/index.js';
+import { CHANCELLOR_SYSTEM_PROMPT, MODEL_IDS, MAX_TURNS, AGENT_TOOLS } from '../../domain/constants/index.js';
 import { ChancellorResponseSchema } from '../../domain/models/schemas.js';
 import type { AgentInvokeOptions, ChancellorResponse } from '../../domain/models/types.js';
 import { CouncilError } from '../../domain/models/types.js';
@@ -16,6 +16,7 @@ export async function invokeChancellor(opts: AgentInvokeOptions): Promise<Chance
     systemPrompt: CHANCELLOR_SYSTEM_PROMPT,
     userMessage,
     maxTurns: opts.max_turns ?? MAX_TURNS.CHANCELLOR,
+    tools: AGENT_TOOLS.CHANCELLOR,
     skipCaveman: opts.skipCaveman,
   });
 

--- a/src/application/executor/agent.ts
+++ b/src/application/executor/agent.ts
@@ -1,5 +1,5 @@
-import { runExecutorWithTools } from '../../infra/agent-sdk/runner.js';
-import { EXECUTOR_SYSTEM_PROMPT, MODEL_IDS, MAX_TURNS } from '../../domain/constants/index.js';
+import { runAgent } from '../../infra/agent-sdk/runner.js';
+import { EXECUTOR_SYSTEM_PROMPT, MODEL_IDS, MAX_TURNS, AGENT_TOOLS } from '../../domain/constants/index.js';
 import { ExecutorResponseSchema } from '../../domain/models/schemas.js';
 import type { AgentInvokeOptions, ExecutorResponse } from '../../domain/models/types.js';
 import { CouncilError } from '../../domain/models/types.js';
@@ -10,12 +10,13 @@ export async function invokeExecutor(opts: AgentInvokeOptions): Promise<Executor
     ? `Task: ${opts.problem}\n\nContext (Chancellor's plan):\n${opts.context}`
     : `Task: ${opts.problem}`;
 
-  const raw = await runExecutorWithTools({
+  const raw = await runAgent({
     role: 'executor',
     model: MODEL_IDS.EXECUTOR,
     systemPrompt: EXECUTOR_SYSTEM_PROMPT,
     userMessage,
     maxTurns: opts.max_turns ?? MAX_TURNS.EXECUTOR,
+    tools: AGENT_TOOLS.EXECUTOR,
     skipCaveman: opts.skipCaveman,
   });
 

--- a/src/application/executor/agent.ts
+++ b/src/application/executor/agent.ts
@@ -5,6 +5,13 @@ import type { AgentInvokeOptions, ExecutorResponse } from '../../domain/models/t
 import { CouncilError } from '../../domain/models/types.js';
 import { logger } from '../../infra/logging/logger.js';
 
+/**
+ * Invokes the executor agent with the provided task/context, extracts and parses any fenced JSON in the agent reply, validates it against `ExecutorResponseSchema`, and returns the validated response.
+ *
+ * @param opts - Invocation options: `opts.problem` is used as the task; if present `opts.context` is included as "Chancellor's plan". May include `opts.max_turns` to override the executor turn limit and `opts.skipCaveman` to control caveman behavior.
+ * @returns The validated `ExecutorResponse` parsed from the agent's output.
+ * @throws CouncilError with code `"INVALID_JSON_RESPONSE"` when the agent's output cannot be parsed as JSON or fails schema validation.
+ */
 export async function invokeExecutor(opts: AgentInvokeOptions): Promise<ExecutorResponse> {
   const userMessage = opts.context
     ? `Task: ${opts.problem}\n\nContext (Chancellor's plan):\n${opts.context}`

--- a/src/domain/constants/index.ts
+++ b/src/domain/constants/index.ts
@@ -15,6 +15,19 @@ export const MAX_TURNS = {
   SUPERVISOR: 2,   // Very tight — review pass only, no iteration needed
 } as const;
 
+// ─── Per-agent tool sets ──────────────────────────────────────────────────────
+// Single source of truth — referenced by each agent module.
+// Chancellor: read-only (plans, never implements — no write/shell access)
+// Executor:   full access (implements, delegates, runs code)
+// Aide:       Read only (must be able to inspect files before transforming them)
+// Supervisor: none (pure review — tool access would allow unintended side effects)
+export const AGENT_TOOLS = {
+  CHANCELLOR: ['Read', 'Glob', 'Grep'] as string[],
+  EXECUTOR:   ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep'] as string[],
+  AIDE:       ['Read'] as string[],
+  SUPERVISOR: [] as string[],
+} as const;
+
 // ─── System prompts ───────────────────────────────────────────────────────────
 // Each prompt ends with an explicit JSON output schema so the model knows
 // the exact shape to return. The user turn carries the actual problem.
@@ -28,8 +41,16 @@ Your responsibilities:
 4. QUALITY OVERSIGHT — define success criteria and measurable outcomes
 5. DELEGATION STRATEGY — specify which steps the Executor should delegate to the Aide
 
+Tool access (read-only):
+You have access to Read, Glob, and Grep. Use them to ground your plan in reality before producing it.
+- Read relevant files before assuming their structure or content
+- Glob to discover what files exist in the codebase
+- Grep to find patterns, imports, or usages that affect your plan
+You MUST NOT write, edit, or execute — planning only. All implementation is the Executor's responsibility.
+
 Your analysis process:
 - Clarify the true problem (not just the stated problem)
+- Inspect the codebase when the problem is file or code related — do not plan blind
 - Identify constraints and dependencies
 - Generate a step-by-step plan with agent assignments
 - Assess risks at each step
@@ -37,7 +58,7 @@ Your analysis process:
 
 Key principles:
 - Think like a strategic advisor, not a task-doer
-- Make plans specific enough to execute
+- Make plans specific enough to execute — use what you read to be precise
 - Always identify what could go wrong
 - Respect token limits — be thorough but concise
 
@@ -154,8 +175,12 @@ Your responsibilities:
 3. IMMEDIATE FEEDBACK — report completion quickly with clean results
 4. QUALITY BASELINE — accurate, specification-compliant output
 
+Tool access:
+You have access to Read. Use it when the task requires inspecting a file's content before transforming or processing it. Do not use it speculatively — only read what is directly needed for the task.
+
 Execution process:
 - Understand the specific task and success criteria
+- If the task references a file, Read it first before producing output
 - Execute directly — do not overthink simple tasks
 - Provide clean, usable output
 - Flag any issues immediately
@@ -166,6 +191,7 @@ Appropriate tasks:
 - Text processing (clean, restructure, summarize)
 - Simple utility functions
 - Template instantiation
+- File content transformation (requires reading the source file first)
 
 NOT appropriate for:
 - Complex algorithm design

--- a/src/infra/agent-sdk/runner.ts
+++ b/src/infra/agent-sdk/runner.ts
@@ -65,9 +65,17 @@ const CLAUDE_BIN = resolveClaude();
 logger.info({ claude: CLAUDE_BIN }, 'claude CLI resolved');
 
 /**
- * Runs a Claude sub-agent via the claude CLI and returns the final result text.
- * Works with OAuth (Claude.ai subscription) and ANTHROPIC_API_KEY — no extra cost
- * if Claude Code is already installed.
+ * Invoke the Claude CLI as a sub-agent to produce the agent's final text output.
+ *
+ * This will run the installed `claude` binary with the provided prompts and options. If
+ * `ANTHROPIC_API_KEY` is unset or empty in the environment passed to this process, the
+ * key is removed for the child process so the CLI falls back to any configured OAuth
+ * (Claude Code) session.
+ *
+ * @param params.tools - Optional list of tool names to permit; when empty, no `--allowedTools` flag is passed
+ * @param params.skipCaveman - When true, do not apply caveman compression to the system prompt
+ * @returns The trimmed text output produced by the Claude CLI
+ * @throws {CouncilError} On spawn failures, non-zero CLI exit codes, or when the agent returns no output
  */
 export async function runAgent(params: RunAgentParams): Promise<string> {
   const { role, model, systemPrompt, userMessage, maxTurns, tools = [], skipCaveman = false } = params;

--- a/src/infra/agent-sdk/runner.ts
+++ b/src/infra/agent-sdk/runner.ts
@@ -166,11 +166,3 @@ export async function runAgent(params: RunAgentParams): Promise<string> {
     });
   });
 }
-
-// Convenience wrapper for the Executor — pre-configured with coding tools.
-export async function runExecutorWithTools(params: RunAgentParams): Promise<string> {
-  return runAgent({
-    ...params,
-    tools: ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep'],
-  });
-}


### PR DESCRIPTION
## Summary

- Chancellor gets `Read`, `Glob`, `Grep` — can inspect the codebase before producing a plan, no more planning blind
- Aide gets `Read` — can read files before transforming them
- Supervisor stays tool-free (pure review, no side effects)
- `AGENT_TOOLS` constant added as single source of truth for all per-agent tool sets
- Removed the `runExecutorWithTools` one-off wrapper — all agents now use `runAgent` + their constant tool set consistently

## Files changed

- `src/domain/constants/index.ts` — new `AGENT_TOOLS` export; Chancellor and Aide system prompts updated to describe tool access and when to use it
- `src/application/chancellor/agent.ts` — passes `AGENT_TOOLS.CHANCELLOR`
- `src/application/aide/agent.ts` — passes `AGENT_TOOLS.AIDE`
- `src/application/executor/agent.ts` — switches from `runExecutorWithTools` to `runAgent` + `AGENT_TOOLS.EXECUTOR`
- `src/infra/agent-sdk/runner.ts` — removes dead `runExecutorWithTools` wrapper
- `README.md` — agent roles table updated with correct tool columns
- `CHANGELOG.md` — feature documented under Unreleased

## Tool access by agent

| Agent | Tools | Reason |
|---|---|---|
| Chancellor | `Read`, `Glob`, `Grep` | Plans based on actual file contents, not assumptions |
| Executor | `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep` | Full implementation access (unchanged) |
| Aide | `Read` | Must read files before transforming them |
| Supervisor | none | Pure review — tool access would risk unintended side effects |

## Test plan

- [ ] Chancellor on a code-related problem uses `Glob`/`Read` to inspect files before producing its plan
- [ ] Aide on a "transform this file" task uses `Read` to fetch the file content first
- [ ] Executor behaviour unchanged — tools still work as before
- [ ] Supervisor makes no tool calls
- [ ] All agents still return valid JSON matching their schemas

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chancellor agent now has read-only filesystem and search tool access (previously had no tools).
  * Aide agent now has read-only file access capability (previously had no tools).
  * Per-agent tool permissions are now centrally defined and enforced.

* **Documentation**
  * Updated CHANGELOG and README to reflect agent tool capabilities.
  * Updated agent system prompts to document available tools and usage guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->