### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-20
+
 ### Added
 - **Per-agent tool access** — Chancellor and Aide now have tool access, configurable via `AGENT_TOOLS` constants:
   - Chancellor: `Read`, `Glob`, `Grep` (read-only — inspects codebase before planning, never writes)
@@ -106,7 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Executor runs with explicit `permissionMode: 'acceptEdits'` rather than relying on inherited default
 - `@anthropic-ai/claude-agent-sdk` pinned to `^0.2.101` (no `latest` in production)
 
-[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/iamvirul/the-council/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/iamvirul/the-council/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/iamvirul/the-council/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/iamvirul/the-council/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/iamvirul/the-council/compare/v0.2.1...v0.2.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "council-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Three-tier AI agent MCP orchestration system: Chancellor (Opus), Executor (Sonnet), Aide (Haiku)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.4.0

### What's in this release

**Per-agent tool access (issue #21)**
- Chancellor: `Read`, `Glob`, `Grep` - inspects codebase before planning, never writes
- Executor: `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep` (unchanged)
- Aide: `Read` - reads files before transforming them
- Supervisor: none (pure review, no side effects)
- `AGENT_TOOLS` constant added as single source of truth
- `runExecutorWithTools` wrapper removed - all agents now use `runAgent` + constant consistently

**Caveman token compression (issue #33)**
- `COUNCIL_CAVEMAN` env var: `off` / `lite` / `full` / `ultra`
- Suffix injection approach - placed after JSON schema for ~50-60% token savings on `full`
- Supervisor exempt - its recommendation stays in normal prose
- Active mode recorded in `session.metrics.caveman_mode`

### Checklist
- [x] Version bumped to 0.4.0 in package.json
- [x] CHANGELOG.md updated
- [x] Build clean