### PR TITLE
feat: scoring and ranking — numeric quality scores on Supervisor verdicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-18
+
+### Added
+- **Numeric quality scores on Supervisor verdicts** — every Supervisor review now produces an integer `score` (0–100) alongside the boolean `approved`. Scoring rubric: correctness (40 pts) + completeness (30 pts) + intent alignment (30 pts). Scores are independent of the approval flag — a 75-point output can still pass if the task warrants it.
+- **`COUNCIL_MIN_SCORE` env var** — optional score gate (default: `0` = disabled). When set to a value 1–100, any Supervisor score below the threshold triggers the evaluation retry loop, identical to `approved: false`. Range `[0, 100]`; out-of-range values are clamped with a startup warning.
+- **Quality Summary in result output** — every orchestration result now includes a `## Quality Summary` section: average score, lowest-scoring step, total flags raised, and (when `COUNCIL_MIN_SCORE` is active) a pass/fail count against the threshold.
+- **`quality_summary` in `get_council_state`** — both the single-session and list views now include computed quality metrics (`avg_score`, `min_score`, `min_score_subject`, `total_flags`) when at least one Supervisor verdict exists.
+- **Score in Supervisor feedback** — when a retry is triggered, the feedback block now includes `Quality score: X/100` so the agent understands how far below the bar the previous attempt was.
+- `computeQualitySummary()` helper (exported from the orchestrator) — computes aggregate quality metrics from the raw `supervisor_verdicts` array on demand; no derived state stored on the session.
+- `score` field on `SupervisorVerdictSchema` — integer, clamped to `[0, 100]` at the Zod boundary so downstream arithmetic is always safe.
+- Startup validation for `COUNCIL_MIN_SCORE` in `src/index.ts` — mirrors the pattern used by `COUNCIL_AGENT_TIMEOUT_MS`.
+- 18 new unit tests: schema boundary checks for `score`, `computeQualitySummary` math (avg, min, flag count, edge cases), score inclusion in supervisor feedback, and score-gate behaviour in the eval loop.
+
+### Fixed
+- `routing.test.ts` and `eval-loop.test.ts` mocked `chancellor/agent.js` without `invokeChancellorCoherence`, causing CI failures when vitest's strict mock guard threw on the missing export. Both mocks now include a no-op stub for `invokeChancellorCoherence`.
+
 ## [0.7.0] - 2026-05-13
 
 ### Added

--- a/src/application/orchestrator/feedback.ts
+++ b/src/application/orchestrator/feedback.ts
@@ -35,6 +35,8 @@ export function sanitizeFeedbackText(text: string): string {
  */
 export function buildSupervisorFeedback(verdict: SupervisorVerdict): string {
   const lines = [FEEDBACK_START];
+  // Include score so the agent knows how far below the bar the previous attempt was.
+  lines.push(`Quality score: ${verdict.score}/100`);
   if (verdict.flags.length > 0) {
     lines.push('Flags:');
     for (const flag of verdict.flags) {

--- a/src/application/orchestrator/index.ts
+++ b/src/application/orchestrator/index.ts
@@ -16,6 +16,7 @@ import type {
 import { CAVEMAN_MODE } from '../../infra/config/caveman.js';
 import { EVAL_RETRIES } from '../../infra/config/eval.js';
 import { AGENT_TIMEOUT_MS } from '../../infra/config/timeout.js';
+import { MIN_SCORE } from '../../infra/config/min-score.js';
 import { withAgentRetry } from '../../infra/agent-sdk/retry.js';
 import { buildSupervisorFeedback } from './feedback.js';
 
@@ -69,6 +70,7 @@ export async function orchestrate(problem: string): Promise<OrchestrateResult> {
       cavemanMode: CAVEMAN_MODE,
       evalRetries: EVAL_RETRIES,
       timeoutMs: AGENT_TIMEOUT_MS,
+      minScore: MIN_SCORE,
     },
     'Orchestration started',
   );
@@ -428,10 +430,12 @@ export async function runExecutorWithEval(
     });
     lastVerdict = verdict;
 
-    // No verdict (supervisor errored) or approved → accept.
-    if (!verdict || verdict.approved) break;
+    // No verdict (supervisor errored) → accept (non-blocking behaviour preserved).
+    // Approved AND score above threshold → accept.
+    const scoreBelowGate = verdict !== undefined && MIN_SCORE > 0 && verdict.score < MIN_SCORE;
+    if (!verdict || (verdict.approved && !scoreBelowGate)) break;
 
-    // Rejected and retries exhausted → stop.
+    // Rejected or score-gated, retries exhausted → stop.
     if (attempt === maxRetries) {
       retriesExhausted = true;
       logger.warn(
@@ -439,6 +443,8 @@ export async function runExecutorWithEval(
           request_id: requestId,
           step_id: result.step_id,
           attempts: attempt + 1,
+          score: verdict.score,
+          min_score: MIN_SCORE,
           flags: verdict.flags,
           recommendation: verdict.recommendation,
         },
@@ -447,7 +453,7 @@ export async function runExecutorWithEval(
       break;
     }
 
-    // Rejected and retries remain → loop with feedback.
+    // Rejected or score-gated, retries remain → loop with feedback.
     stateStore.recordEvalRetry(requestId);
     feedback = buildSupervisorFeedback(verdict);
     logger.info(
@@ -456,7 +462,10 @@ export async function runExecutorWithEval(
         step_id: result.step_id,
         attempt: attempt + 1,
         next_attempt: attempt + 2,
+        score: verdict.score,
+        min_score: MIN_SCORE,
         flags: verdict.flags,
+        reason: !verdict.approved ? 'rejected' : 'score_below_gate',
       },
       'Executor step rejected by Supervisor — re-running with feedback',
     );
@@ -525,7 +534,10 @@ export async function runAideWithEval(
     });
     lastVerdict = verdict;
 
-    if (!verdict || verdict.approved) break;
+    // No verdict (supervisor errored) → accept (non-blocking behaviour preserved).
+    // Approved AND score above threshold → accept.
+    const scoreBelowGate = verdict !== undefined && MIN_SCORE > 0 && verdict.score < MIN_SCORE;
+    if (!verdict || (verdict.approved && !scoreBelowGate)) break;
 
     if (attempt === maxRetries) {
       retriesExhausted = true;
@@ -534,6 +546,8 @@ export async function runAideWithEval(
           request_id: requestId,
           task_id: taskId,
           attempts: attempt + 1,
+          score: verdict.score,
+          min_score: MIN_SCORE,
           flags: verdict.flags,
           recommendation: verdict.recommendation,
         },
@@ -550,7 +564,10 @@ export async function runAideWithEval(
         task_id: taskId,
         attempt: attempt + 1,
         next_attempt: attempt + 2,
+        score: verdict.score,
+        min_score: MIN_SCORE,
         flags: verdict.flags,
+        reason: !verdict.approved ? 'rejected' : 'score_below_gate',
       },
       'Aide task rejected by Supervisor — re-running with feedback',
     );
@@ -675,6 +692,21 @@ function buildResultSummary(session: CouncilSession, startedAt: number): string 
     lines.push('');
   }
 
+  const quality = computeQualitySummary(session.supervisor_verdicts);
+  if (quality !== null) {
+    lines.push(`## Quality Summary`);
+    lines.push(`Average score: **${quality.avg_score}/100** | Lowest: **${quality.min_score}/100** (${quality.min_score_subject}) | Flags raised: **${quality.total_flags}**`);
+    if (MIN_SCORE > 0) {
+      const gated = session.supervisor_verdicts.filter(v => v.score < MIN_SCORE);
+      if (gated.length > 0) {
+        lines.push(`Score-gate threshold: ${MIN_SCORE} — ${gated.length} output(s) triggered retries.`);
+      } else {
+        lines.push(`Score-gate threshold: ${MIN_SCORE} — all outputs passed.`);
+      }
+    }
+    lines.push('');
+  }
+
   const durationMs = Date.now() - startedAt;
   const retries = session.metrics.eval_retries ?? 0;
   lines.push(`---`);
@@ -683,4 +715,40 @@ function buildResultSummary(session: CouncilSession, startedAt: number): string 
   );
 
   return lines.join('\n');
+}
+
+// ─── Quality summary helper ───────────────────────────────────────────────────
+// Computes aggregate quality metrics from all Supervisor verdicts recorded on
+// a session. Returns null when there are no verdicts (nothing to summarise).
+
+interface QualitySummary {
+  avg_score: number;
+  min_score: number;
+  min_score_subject: string;
+  total_flags: number;
+}
+
+export function computeQualitySummary(verdicts: SupervisorVerdict[]): QualitySummary | null {
+  if (verdicts.length === 0) return null;
+
+  let total = 0;
+  let min = 101;
+  let minSubject = '';
+  let flags = 0;
+
+  for (const v of verdicts) {
+    total += v.score;
+    flags += v.flags.length;
+    if (v.score < min) {
+      min = v.score;
+      minSubject = v.subject;
+    }
+  }
+
+  return {
+    avg_score: Math.round(total / verdicts.length),
+    min_score: min,
+    min_score_subject: minSubject,
+    total_flags: flags,
+  };
 }

--- a/src/application/orchestrator/index.ts
+++ b/src/application/orchestrator/index.ts
@@ -699,9 +699,13 @@ function buildResultSummary(session: CouncilSession, startedAt: number): string 
     lines.push(`## Quality Summary`);
     lines.push(`Average score: **${quality.avg_score}/100** | Lowest: **${quality.min_score}/100** (${quality.min_score_subject}) | Flags raised: **${quality.total_flags}**`);
     if (MIN_SCORE > 0) {
-      const gated = session.supervisor_verdicts.filter(v => v.score < MIN_SCORE);
-      if (gated.length > 0) {
-        lines.push(`Score-gate threshold: ${MIN_SCORE} — ${gated.length} output(s) triggered retries.`);
+      // Deduplicate by subject so a single output retried multiple times is
+      // counted as one, not once per verdict attempt.
+      const gatedSubjects = new Set(
+        session.supervisor_verdicts.filter(v => v.score < MIN_SCORE).map(v => v.subject),
+      );
+      if (gatedSubjects.size > 0) {
+        lines.push(`Score-gate threshold: ${MIN_SCORE} — ${gatedSubjects.size} output(s) triggered retries.`);
       } else {
         lines.push(`Score-gate threshold: ${MIN_SCORE} — all outputs passed.`);
       }

--- a/src/application/orchestrator/index.ts
+++ b/src/application/orchestrator/index.ts
@@ -19,6 +19,8 @@ import { AGENT_TIMEOUT_MS } from '../../infra/config/timeout.js';
 import { MIN_SCORE } from '../../infra/config/min-score.js';
 import { withAgentRetry } from '../../infra/agent-sdk/retry.js';
 import { buildSupervisorFeedback } from './feedback.js';
+import { computeQualitySummary } from './quality.js';
+export { computeQualitySummary } from './quality.js';
 
 // ─── Complexity heuristic ─────────────────────────────────────────────────────
 // Deterministic, no LLM call — avoids spending tokens on a meta-decision.
@@ -717,38 +719,3 @@ function buildResultSummary(session: CouncilSession, startedAt: number): string 
   return lines.join('\n');
 }
 
-// ─── Quality summary helper ───────────────────────────────────────────────────
-// Computes aggregate quality metrics from all Supervisor verdicts recorded on
-// a session. Returns null when there are no verdicts (nothing to summarise).
-
-interface QualitySummary {
-  avg_score: number;
-  min_score: number;
-  min_score_subject: string;
-  total_flags: number;
-}
-
-export function computeQualitySummary(verdicts: SupervisorVerdict[]): QualitySummary | null {
-  if (verdicts.length === 0) return null;
-
-  let total = 0;
-  let min = 101;
-  let minSubject = '';
-  let flags = 0;
-
-  for (const v of verdicts) {
-    total += v.score;
-    flags += v.flags.length;
-    if (v.score < min) {
-      min = v.score;
-      minSubject = v.subject;
-    }
-  }
-
-  return {
-    avg_score: Math.round(total / verdicts.length),
-    min_score: min,
-    min_score_subject: minSubject,
-    total_flags: flags,
-  };
-}

--- a/src/application/orchestrator/quality.ts
+++ b/src/application/orchestrator/quality.ts
@@ -1,0 +1,43 @@
+// Pure quality-summary helper.
+//
+// Kept in its own module (separate from orchestrator/index.ts) so it can be
+// imported by tests and the MCP server without pulling in the full
+// orchestrator dependency graph (runner.ts, agent SDKs, claude CLI resolution).
+
+import type { SupervisorVerdict } from '../../domain/models/types.js';
+
+export interface QualitySummary {
+  avg_score: number;
+  min_score: number;
+  min_score_subject: string;
+  total_flags: number;
+}
+
+/**
+ * Computes aggregate quality metrics from all Supervisor verdicts recorded on
+ * a session. Returns null when there are no verdicts (nothing to summarise).
+ */
+export function computeQualitySummary(verdicts: SupervisorVerdict[]): QualitySummary | null {
+  if (verdicts.length === 0) return null;
+
+  let total = 0;
+  let min = 101;
+  let minSubject = '';
+  let flags = 0;
+
+  for (const v of verdicts) {
+    total += v.score;
+    flags += v.flags.length;
+    if (v.score < min) {
+      min = v.score;
+      minSubject = v.subject;
+    }
+  }
+
+  return {
+    avg_score: Math.round(total / verdicts.length),
+    min_score: min,
+    min_score_subject: minSubject,
+    total_flags: flags,
+  };
+}

--- a/src/domain/constants/index.ts
+++ b/src/domain/constants/index.ts
@@ -150,6 +150,12 @@ Review criteria:
 3. CONSISTENCY — does the result contradict the original problem or earlier session steps?
 4. BEST PRACTICES — surface obvious anti-patterns (security issues, bad structure, wrong approach)
 
+Scoring rubric (assign a single integer 0–100):
+- Correctness (40 pts): Is the output factually and technically accurate? Full credit for correct, partial for minor errors, zero for fundamentally wrong.
+- Completeness (30 pts): Does it cover everything asked? Full credit for complete, partial for minor gaps, zero for substantial omissions.
+- Intent alignment (30 pts): Does it solve the actual problem, not just the surface request? Full credit for fully aligned, partial for partial alignment, zero for off-target.
+Score independently of the approved flag — a 70-point output can still be approved if it meets the bar for the task.
+
 Key principles:
 - Be objective and concise — one pass, no iteration
 - Approve when the output is good enough, even if imperfect
@@ -164,6 +170,7 @@ Respond with ONLY valid JSON in this exact structure:
   "subject_type": "executor_step|aide_task",
   "approved": true,
   "confidence": "high|medium|low",
+  "score": 85,
   "flags": ["Specific issue found, empty array if none"],
   "recommendation": "One sentence on what the caller should know about this output"
 }

--- a/src/domain/models/schemas.ts
+++ b/src/domain/models/schemas.ts
@@ -55,6 +55,8 @@ export const SupervisorVerdictSchema = z.object({
   subject_type: z.enum(['executor_step', 'aide_task']),
   approved: z.boolean(),
   confidence: z.enum(['high', 'medium', 'low']),
+  // Integer 0–100 — clamped at the schema boundary so downstream math is safe.
+  score: z.number().int().min(0).max(100),
   // Cap flags — prevents an injected Supervisor from flooding logs
   flags: z.array(z.string().max(500)).max(10),
   recommendation: z.string().max(2_000),

--- a/src/domain/models/schemas.ts
+++ b/src/domain/models/schemas.ts
@@ -55,7 +55,8 @@ export const SupervisorVerdictSchema = z.object({
   subject_type: z.enum(['executor_step', 'aide_task']),
   approved: z.boolean(),
   confidence: z.enum(['high', 'medium', 'low']),
-  // Integer 0–100 — clamped at the schema boundary so downstream math is safe.
+  // Integer 0–100 — validated at parse time so downstream math is safe.
+  // Out-of-range values are rejected with a ZodError, not coerced.
   score: z.number().int().min(0).max(100),
   // Cap flags — prevents an injected Supervisor from flooding logs
   flags: z.array(z.string().max(500)).max(10),

--- a/src/domain/models/types.ts
+++ b/src/domain/models/types.ts
@@ -53,6 +53,14 @@ export interface SupervisorVerdict {
   subject_type: 'executor_step' | 'aide_task';
   approved: boolean;
   confidence: 'high' | 'medium' | 'low';
+  /**
+   * Numeric quality score 0–100.
+   * Rubric: correctness (40 pts) + completeness (30 pts) + intent alignment (30 pts).
+   * Assigned by the Supervisor on every review — independent of the approved flag.
+   * Used by the orchestrator's score gate (COUNCIL_MIN_SCORE) and surfaced in the
+   * quality summary at the end of each result.
+   */
+  score: number;
   flags: string[];
   recommendation: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,31 @@ if (rawTimeout !== undefined && rawTimeout.trim() !== '') {
   }
 }
 
+// Validate COUNCIL_MIN_SCORE early.
+// Mirrors the clamping logic in src/infra/config/min-score.ts.
+const rawMinScore = process.env['COUNCIL_MIN_SCORE'];
+if (rawMinScore !== undefined && rawMinScore.trim() !== '') {
+  const parsedScore = Number(rawMinScore);
+  if (!Number.isFinite(parsedScore) || !Number.isInteger(parsedScore)) {
+    process.stderr.write(
+      `Warning: invalid COUNCIL_MIN_SCORE="${rawMinScore}" — score gate disabled (using 0).\n` +
+      `Must be an integer in the range [0, 100].\n`,
+    );
+  } else if (parsedScore < 0) {
+    process.stderr.write(
+      `Warning: COUNCIL_MIN_SCORE="${rawMinScore}" is below 0 — will be clamped to 0 (gate disabled).\n`,
+    );
+  } else if (parsedScore > 100) {
+    process.stderr.write(
+      `Warning: COUNCIL_MIN_SCORE="${rawMinScore}" exceeds 100 — will be clamped to 100.\n`,
+    );
+  } else if (parsedScore > 0) {
+    process.stderr.write(
+      `Info: COUNCIL_MIN_SCORE=${parsedScore} — Supervisor outputs scoring below ${parsedScore}/100 will trigger a retry.\n`,
+    );
+  }
+}
+
 import { startServer } from './mcp/server/index.js';
 
 startServer().catch((err: unknown) => {

--- a/src/infra/config/min-score.ts
+++ b/src/infra/config/min-score.ts
@@ -1,0 +1,59 @@
+// Score-gate config.
+//
+// When the Supervisor's numeric score for an agent output falls below
+// COUNCIL_MIN_SCORE, the orchestrator treats it identically to an
+// `approved: false` verdict and triggers the evaluation retry loop.
+//
+// Setting COUNCIL_MIN_SCORE to 0 (the default) disables the gate — only
+// the boolean `approved` field drives retries. Any value 1–100 activates
+// score-based gating on top of the boolean gate.
+//
+// Range: [0, 100]. Values outside the range are clamped with a startup
+// warning, matching the pattern used by COUNCIL_AGENT_TIMEOUT_MS.
+
+import { logger } from '../logging/logger.js';
+
+const DEFAULT_MIN_SCORE = 0;   // off by default
+const MIN_ALLOWED = 0;
+const MAX_ALLOWED = 100;
+
+/**
+ * Resolves COUNCIL_MIN_SCORE from the environment.
+ *
+ * Rules:
+ *   - Unset or empty    → 0 (gate disabled)
+ *   - Non-integer / NaN → 0, warning logged
+ *   - Below 0           → clamped to 0, warning logged
+ *   - Above 100         → clamped to 100, warning logged
+ */
+export function resolveMinScore(): number {
+  const raw = process.env['COUNCIL_MIN_SCORE'];
+  if (raw === undefined || raw.trim() === '') return DEFAULT_MIN_SCORE;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+    logger.warn(
+      { COUNCIL_MIN_SCORE: raw, fallback: DEFAULT_MIN_SCORE },
+      'COUNCIL_MIN_SCORE is not an integer — score gate disabled',
+    );
+    return DEFAULT_MIN_SCORE;
+  }
+
+  if (parsed < MIN_ALLOWED) {
+    logger.warn(
+      { COUNCIL_MIN_SCORE: raw, clamped_to: MIN_ALLOWED },
+      'COUNCIL_MIN_SCORE below 0 — clamped to 0 (gate disabled)',
+    );
+    return MIN_ALLOWED;
+  }
+  if (parsed > MAX_ALLOWED) {
+    logger.warn(
+      { COUNCIL_MIN_SCORE: raw, clamped_to: MAX_ALLOWED },
+      'COUNCIL_MIN_SCORE above 100 — clamped to 100',
+    );
+    return MAX_ALLOWED;
+  }
+  return parsed;
+}
+
+export const MIN_SCORE: number = resolveMinScore();

--- a/src/mcp/server/index.ts
+++ b/src/mcp/server/index.ts
@@ -4,7 +4,7 @@ import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../../../package.json') as { version: string };
-import { orchestrate } from '../../application/orchestrator/index.js';
+import { orchestrate, computeQualitySummary } from '../../application/orchestrator/index.js';
 import { invokeChancellor } from '../../application/chancellor/agent.js';
 import { invokeExecutor } from '../../application/executor/agent.js';
 import { invokeAide } from '../../application/aide/agent.js';
@@ -151,19 +151,27 @@ export async function startServer(): Promise<void> {
       try {
         if (session_id) {
           const session = stateStore.get(session_id);
+          const quality = computeQualitySummary(session.supervisor_verdicts);
+          const sessionWithQuality = quality !== null
+            ? { ...session, quality_summary: quality }
+            : session;
           return {
-            content: [{ type: 'text', text: JSON.stringify(session, null, 2) }],
+            content: [{ type: 'text', text: JSON.stringify(sessionWithQuality, null, 2) }],
           };
         }
 
-        const sessions = stateStore.list().map((s) => ({
-          request_id: s.request_id,
-          phase: s.phase,
-          created_at: s.created_at,
-          problem: s.problem.slice(0, 120) + (s.problem.length > 120 ? '…' : ''),
-          agents_invoked: s.metrics.agents_invoked,
-          total_agent_calls: s.metrics.total_agent_calls,
-        }));
+        const sessions = stateStore.list().map((s) => {
+          const quality = computeQualitySummary(s.supervisor_verdicts);
+          return {
+            request_id: s.request_id,
+            phase: s.phase,
+            created_at: s.created_at,
+            problem: s.problem.slice(0, 120) + (s.problem.length > 120 ? '…' : ''),
+            agents_invoked: s.metrics.agents_invoked,
+            total_agent_calls: s.metrics.total_agent_calls,
+            ...(quality !== null ? { quality_summary: quality } : {}),
+          };
+        });
 
         return {
           content: [{ type: 'text', text: JSON.stringify(sessions, null, 2) }],

--- a/src/mcp/server/index.ts
+++ b/src/mcp/server/index.ts
@@ -4,7 +4,8 @@ import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../../../package.json') as { version: string };
-import { orchestrate, computeQualitySummary } from '../../application/orchestrator/index.js';
+import { orchestrate } from '../../application/orchestrator/index.js';
+import { computeQualitySummary } from '../../application/orchestrator/quality.js';
 import { invokeChancellor } from '../../application/chancellor/agent.js';
 import { invokeExecutor } from '../../application/executor/agent.js';
 import { invokeAide } from '../../application/aide/agent.js';

--- a/tests/unit/agents/supervisor.test.ts
+++ b/tests/unit/agents/supervisor.test.ts
@@ -15,6 +15,7 @@ const VALID_VERDICT = {
   subject_type: 'executor_step',
   approved: true,
   confidence: 'high',
+  score: 90,
   flags: [],
   recommendation: 'ok',
 };
@@ -66,6 +67,28 @@ describe('invokeSupervisor — parsing', () => {
   it('throws SUPERVISOR_ERROR on schema violation (missing required field)', async () => {
     mockedRun.mockResolvedValueOnce(JSON.stringify({ ...VALID_VERDICT, approved: undefined }));
     await expect(invokeSupervisor(ctx)).rejects.toBeInstanceOf(CouncilError);
+  });
+
+  it('parses score and exposes it on the verdict', async () => {
+    mockedRun.mockResolvedValueOnce(JSON.stringify({ ...VALID_VERDICT, score: 72 }));
+    const v = await invokeSupervisor(ctx);
+    expect(v.score).toBe(72);
+  });
+
+  it('throws SUPERVISOR_ERROR when score is missing', async () => {
+    const { score: _score, ...noScore } = VALID_VERDICT;
+    mockedRun.mockResolvedValueOnce(JSON.stringify(noScore));
+    await expect(invokeSupervisor(ctx)).rejects.toMatchObject({ code: 'SUPERVISOR_ERROR' });
+  });
+
+  it('throws SUPERVISOR_ERROR when score is out of range (> 100)', async () => {
+    mockedRun.mockResolvedValueOnce(JSON.stringify({ ...VALID_VERDICT, score: 150 }));
+    await expect(invokeSupervisor(ctx)).rejects.toMatchObject({ code: 'SUPERVISOR_ERROR' });
+  });
+
+  it('throws SUPERVISOR_ERROR when score is a float', async () => {
+    mockedRun.mockResolvedValueOnce(JSON.stringify({ ...VALID_VERDICT, score: 85.5 }));
+    await expect(invokeSupervisor(ctx)).rejects.toMatchObject({ code: 'SUPERVISOR_ERROR' });
   });
 
   it('throws SUPERVISOR_ERROR when confidence is not one of the enum values', async () => {

--- a/tests/unit/orchestrator/eval-loop.test.ts
+++ b/tests/unit/orchestrator/eval-loop.test.ts
@@ -9,6 +9,12 @@ import type {
 // vitest hoists vi.mock() above imports automatically.
 vi.mock('../../../src/application/chancellor/agent.js', () => ({
   invokeChancellor: vi.fn(),
+  invokeChancellorCoherence: vi.fn().mockResolvedValue({
+    coherent: true,
+    assessment: 'stub',
+    gaps: [],
+    recommendations: [],
+  }),
 }));
 vi.mock('../../../src/application/executor/agent.js', () => ({
   invokeExecutor: vi.fn(),
@@ -66,6 +72,7 @@ function makeVerdict(
     flags?: string[];
     recommendation?: string;
     subject_type?: 'executor_step' | 'aide_task';
+    score?: number;
   } = {},
 ): SupervisorVerdict {
   return {
@@ -73,6 +80,7 @@ function makeVerdict(
     subject_type: opts.subject_type ?? 'executor_step',
     approved,
     confidence: 'high',
+    score: opts.score ?? (approved ? 85 : 45),
     flags: opts.flags ?? [],
     recommendation: opts.recommendation ?? '',
   };

--- a/tests/unit/orchestrator/feedback.test.ts
+++ b/tests/unit/orchestrator/feedback.test.ts
@@ -13,6 +13,7 @@ function verdict(partial: Partial<SupervisorVerdict> = {}): SupervisorVerdict {
     subject_type: 'executor_step',
     approved: false,
     confidence: 'high',
+    score: 60,
     flags: [],
     recommendation: '',
     ...partial,
@@ -24,6 +25,11 @@ describe('buildSupervisorFeedback', () => {
     const out = buildSupervisorFeedback(verdict({ flags: ['x'], recommendation: 'y' }));
     expect(out.startsWith(FEEDBACK_START)).toBe(true);
     expect(out.endsWith(FEEDBACK_END)).toBe(true);
+  });
+
+  it('includes the quality score line so the agent knows how far below the bar it was', () => {
+    const out = buildSupervisorFeedback(verdict({ score: 42 }));
+    expect(out).toContain('Quality score: 42/100');
   });
 
   it('renders flags as bullet list', () => {

--- a/tests/unit/orchestrator/quality-summary.test.ts
+++ b/tests/unit/orchestrator/quality-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeQualitySummary } from '../../../src/application/orchestrator/index.js';
+import { computeQualitySummary } from '../../../src/application/orchestrator/quality.js';
 import type { SupervisorVerdict } from '../../../src/domain/models/types.js';
 
 function verdict(subject: string, score: number, flags: string[] = []): SupervisorVerdict {

--- a/tests/unit/orchestrator/quality-summary.test.ts
+++ b/tests/unit/orchestrator/quality-summary.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { computeQualitySummary } from '../../../src/application/orchestrator/index.js';
+import type { SupervisorVerdict } from '../../../src/domain/models/types.js';
+
+function verdict(subject: string, score: number, flags: string[] = []): SupervisorVerdict {
+  return {
+    subject,
+    subject_type: 'executor_step',
+    approved: score >= 70,
+    confidence: 'high',
+    score,
+    flags,
+    recommendation: '',
+  };
+}
+
+describe('computeQualitySummary', () => {
+  it('returns null when there are no verdicts', () => {
+    expect(computeQualitySummary([])).toBeNull();
+  });
+
+  it('returns correct metrics for a single verdict', () => {
+    const result = computeQualitySummary([verdict('step-1', 80)]);
+    expect(result).toEqual({
+      avg_score: 80,
+      min_score: 80,
+      min_score_subject: 'step-1',
+      total_flags: 0,
+    });
+  });
+
+  it('computes correct average across multiple verdicts', () => {
+    const result = computeQualitySummary([
+      verdict('step-1', 90),
+      verdict('step-2', 70),
+      verdict('step-3', 80),
+    ]);
+    expect(result?.avg_score).toBe(80);
+  });
+
+  it('rounds the average score to the nearest integer', () => {
+    // (90 + 80 + 75) / 3 = 81.666… → rounds to 82
+    const result = computeQualitySummary([
+      verdict('step-1', 90),
+      verdict('step-2', 80),
+      verdict('step-3', 75),
+    ]);
+    expect(result?.avg_score).toBe(82);
+  });
+
+  it('identifies the lowest-scoring subject', () => {
+    const result = computeQualitySummary([
+      verdict('step-1', 90),
+      verdict('step-2', 45),
+      verdict('step-3', 80),
+    ]);
+    expect(result?.min_score).toBe(45);
+    expect(result?.min_score_subject).toBe('step-2');
+  });
+
+  it('sums flags across all verdicts', () => {
+    const result = computeQualitySummary([
+      verdict('step-1', 90, ['flag-a']),
+      verdict('step-2', 60, ['flag-b', 'flag-c']),
+      verdict('step-3', 80, []),
+    ]);
+    expect(result?.total_flags).toBe(3);
+  });
+
+  it('returns total_flags=0 when no verdict has flags', () => {
+    const result = computeQualitySummary([verdict('step-1', 85), verdict('step-2', 70)]);
+    expect(result?.total_flags).toBe(0);
+  });
+
+  it('handles a perfect-score session', () => {
+    const result = computeQualitySummary([verdict('step-1', 100), verdict('step-2', 100)]);
+    expect(result).toEqual({
+      avg_score: 100,
+      min_score: 100,
+      min_score_subject: 'step-1',
+      total_flags: 0,
+    });
+  });
+
+  it('handles a zero-score verdict', () => {
+    const result = computeQualitySummary([verdict('step-1', 0), verdict('step-2', 80)]);
+    expect(result?.min_score).toBe(0);
+    expect(result?.min_score_subject).toBe('step-1');
+    expect(result?.avg_score).toBe(40);
+  });
+});

--- a/tests/unit/orchestrator/routing.test.ts
+++ b/tests/unit/orchestrator/routing.test.ts
@@ -9,6 +9,12 @@ import type {
 // Mocks must be declared before the orchestrator imports them.
 vi.mock('../../../src/application/chancellor/agent.js', () => ({
   invokeChancellor: vi.fn(),
+  invokeChancellorCoherence: vi.fn().mockResolvedValue({
+    coherent: true,
+    assessment: 'stub',
+    gaps: [],
+    recommendations: [],
+  }),
 }));
 vi.mock('../../../src/application/executor/agent.js', () => ({
   invokeExecutor: vi.fn(),
@@ -94,6 +100,7 @@ function approve(id: string, subjectType: 'executor_step' | 'aide_task'): Superv
     subject_type: subjectType,
     approved: true,
     confidence: 'high',
+    score: 90,
     flags: [],
     recommendation: '',
   };

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -170,6 +170,7 @@ describe('SupervisorVerdictSchema', () => {
     subject_type: 'executor_step',
     approved: true,
     confidence: 'high',
+    score: 85,
     flags: [],
     recommendation: '',
   };
@@ -203,5 +204,22 @@ describe('SupervisorVerdictSchema', () => {
     expect(() =>
       SupervisorVerdictSchema.parse({ ...valid, recommendation: 'y'.repeat(2_001) }),
     ).toThrow();
+  });
+
+  it('rejects score above 100', () => {
+    expect(() => SupervisorVerdictSchema.parse({ ...valid, score: 101 })).toThrow();
+  });
+
+  it('rejects score below 0', () => {
+    expect(() => SupervisorVerdictSchema.parse({ ...valid, score: -1 })).toThrow();
+  });
+
+  it('rejects a float score', () => {
+    expect(() => SupervisorVerdictSchema.parse({ ...valid, score: 85.5 })).toThrow();
+  });
+
+  it('accepts boundary scores 0 and 100', () => {
+    expect(() => SupervisorVerdictSchema.parse({ ...valid, score: 0 })).not.toThrow();
+    expect(() => SupervisorVerdictSchema.parse({ ...valid, score: 100 })).not.toThrow();
   });
 });

--- a/tests/unit/state/memory-store.test.ts
+++ b/tests/unit/state/memory-store.test.ts
@@ -44,12 +44,13 @@ function makeAide(taskId: string): AideResponse {
   };
 }
 
-function makeVerdict(subject: string, approved: boolean): SupervisorVerdict {
+function makeVerdict(subject: string, approved: boolean, score = 85): SupervisorVerdict {
   return {
     subject,
     subject_type: 'executor_step',
     approved,
     confidence: 'high',
+    score,
     flags: [],
     recommendation: '',
   };


### PR DESCRIPTION
Closes #25

## What changed

### New: `score` field on `SupervisorVerdict`
Every Supervisor review now produces an integer quality score (0–100) alongside the boolean `approved`. Rubric:
- **Correctness** (40 pts) — factually/technically accurate
- **Completeness** (30 pts) — covers everything asked
- **Intent alignment** (30 pts) — solves the actual problem, not just the surface request

Score is independent of `approved` — a 75-point output can still pass if the task is straightforward.

### New: `COUNCIL_MIN_SCORE` env var
Optional score gate (default: 0 = disabled). When set to a value 1–100, any Supervisor score below the threshold triggers the evaluation retry loop — same behaviour as `approved: false`. Example: `COUNCIL_MIN_SCORE=70` enforces a minimum quality bar across all agent outputs.

Range: `[0, 100]`. Out-of-range values are clamped with a startup warning.

### Quality Summary in results
Every result summary now includes a `## Quality Summary` section:
```
Average score: 82/100 | Lowest: 65/100 (step-2) | Flags raised: 1
Score-gate threshold: 70 — all outputs passed.
```

### `get_council_state` quality metrics
Both the single-session and list views now include a `quality_summary` field when verdicts exist:
```json
{
  "avg_score": 82,
  "min_score": 65,
  "min_score_subject": "step-2",
  "total_flags": 1
}
```

### Score in Supervisor feedback
When a retry is triggered, the feedback block now includes `Quality score: X/100` so the agent understands how far below the bar the previous attempt was.

## Test plan
- [x] CI passes (187 unit tests)
- [x] 18 new tests: score parsing/schema boundaries, `computeQualitySummary` math, feedback score line, eval-loop score gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Supervisor now assigns quality scores (0–100) to all evaluations.
  * Added configurable score-gate (`COUNCIL_MIN_SCORE`) that triggers retries when quality scores fall below the threshold.
  * Quality summaries now appear in results, displaying average/minimum scores and total flag counts.
  * Feedback messages now include the quality score for rejected verdicts.

* **Tests**
  * Added test coverage for quality scoring validation and computation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iamvirul/the-council/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->