### PR TITLE
release: v0.8.0 — scoring and ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.0] - 2026-05-18
 
 ### Added
-- **Numeric quality scores on Supervisor verdicts** — every Supervisor review now produces an integer `score` (0–100) alongside the boolean `approved`. Scoring rubric: correctness (40 pts) + completeness (30 pts) + intent alignment (30 pts). Scores are independent of the approval flag — a 75-point output can still pass if the task warrants it.
+- **Numeric quality scores on Supervisor verdicts** — every Supervisor review now produces an optional integer `score` (0–100) alongside the boolean `approved`. Scoring rubric: correctness (40 pts) + completeness (30 pts) + intent alignment (30 pts). Scores are independent of the approval flag — a 75-point output can still pass if the task warrants it.
 - **`COUNCIL_MIN_SCORE` env var** — optional score gate (default: `0` = disabled). When set to a value 1–100, any Supervisor score below the threshold triggers the evaluation retry loop, identical to `approved: false`. Range `[0, 100]`; out-of-range values are clamped with a startup warning.
-- **Quality Summary in result output** — every orchestration result now includes a `## Quality Summary` section: average score, lowest-scoring step, total flags raised, and (when `COUNCIL_MIN_SCORE` is active) a pass/fail count against the threshold.
+- **Quality Summary in result output** — every orchestration result now includes a `## Quality Summary` section: average score, lowest-scoring step, total flags raised, and (when `COUNCIL_MIN_SCORE` is active) a pass/fail count against the threshold. Falls back to flag-count-only when the model omits scores.
 - **`quality_summary` in `get_council_state`** — both the single-session and list views now include computed quality metrics (`avg_score`, `min_score`, `min_score_subject`, `total_flags`) when at least one Supervisor verdict exists.
 - **Score in Supervisor feedback** — when a retry is triggered, the feedback block now includes `Quality score: X/100` so the agent understands how far below the bar the previous attempt was.
-- `computeQualitySummary()` helper (exported from the orchestrator) — computes aggregate quality metrics from the raw `supervisor_verdicts` array on demand; no derived state stored on the session.
-- `score` field on `SupervisorVerdictSchema` — integer, clamped to `[0, 100]` at the Zod boundary so downstream arithmetic is always safe.
-- Startup validation for `COUNCIL_MIN_SCORE` in `src/index.ts` — mirrors the pattern used by `COUNCIL_AGENT_TIMEOUT_MS`.
-- 18 new unit tests: schema boundary checks for `score`, `computeQualitySummary` math (avg, min, flag count, edge cases), score inclusion in supervisor feedback, and score-gate behaviour in the eval loop.
+- `computeQualitySummary()` helper (exported from `orchestrator/quality.ts`) — pure module with no infra dependencies; computes aggregate metrics from `supervisor_verdicts` on demand.
+- `src/infra/config/min-score.ts` — `COUNCIL_MIN_SCORE` resolution with clamping/validation, matching the pattern used by `COUNCIL_AGENT_TIMEOUT_MS`.
+- Startup validation for `COUNCIL_MIN_SCORE` in `src/index.ts`.
+- 30 new unit tests across 4 new/updated test files: schema boundary checks, `computeQualitySummary` math (scored, unscored, mixed), score in feedback block, score gate behaviour, `buildResultSummary` Quality Summary rendering.
 
 ### Fixed
-- `routing.test.ts` and `eval-loop.test.ts` mocked `chancellor/agent.js` without `invokeChancellorCoherence`, causing CI failures when vitest's strict mock guard threw on the missing export. Both mocks now include a no-op stub for `invokeChancellorCoherence`.
+- **Supervisor verdicts silently dropped when model omits score** — `score` is now optional on `SupervisorVerdict` (type and schema). Previously a required field caused Zod to reject the entire verdict when Haiku omitted it, leaving `supervisor_verdicts` empty and the eval loop without signal. Verdicts are now always recorded; score-gating and the Quality Summary activate only when a score is present.
+- **Score-gate overcounting in summary** — the "X output(s) triggered retries" count now deduplicates by `subject` so a single output retried multiple times counts as one.
+- **Misleading schema comment** — `"clamped at the schema boundary"` corrected to `"validated at parse time"` (Zod rejects out-of-range values; it does not coerce them).
+- **`computeQualitySummary` imported from orchestrator entry point** — moved to `src/application/orchestrator/quality.ts` (no infra imports) so tests can import it without triggering claude CLI resolution at module load time.
+- `routing.test.ts` and `eval-loop.test.ts` mocked `chancellor/agent.js` without `invokeChancellorCoherence`, causing CI failures. Both mocks now include a stub.
 
 ## [0.7.0] - 2026-05-13
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "council-mcp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Three-tier AI agent MCP orchestration system: Chancellor (Opus), Executor (Sonnet), Aide (Haiku)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Numeric quality scores (0–100) on every Supervisor verdict via `COUNCIL_MIN_SCORE` score gate
- `quality_summary` field in `get_council_state` responses and Quality Summary section in result output
- Made `SupervisorVerdict.score` optional (Haiku intermittently omits the field; Zod now accepts verdicts with or without a score so verdicts are never silently dropped)
- Extracted `computeQualitySummary()` to `src/application/orchestrator/quality.ts` to break a transitive `runner.ts` import that caused CI failures
- Fixed score-gate deduplication bug (was counting per-retry instead of per-subject)
- Strengthened Supervisor system prompt with explicit scoring rubric and "MUST produce" instruction
- 30 new tests across `quality-summary`, `result-summary`, and `eval-loop` suites (199 total, all passing)

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — 199/199 pass
- [x] Local Claude Desktop test: verdicts recorded with scores, Quality Summary renders, score gate fires on retry